### PR TITLE
Add overall discretization results to Euler approx solver notebook.

### DIFF
--- a/Euler_approximate_solvers.ipynb
+++ b/Euler_approximate_solvers.ipynb
@@ -62,14 +62,15 @@
     "\n",
     "# Sod shock tube\n",
     "left_state  = np.array(Primitive_State(Density = 3.,\n",
-    "                                       Velocity = -0.5,\n",
+    "                                       Velocity = -0.5/3.,\n",
     "                                       Pressure = 2.))\n",
     "right_state = np.array(Primitive_State(Density = 1.,\n",
     "                                       Velocity = 0.,\n",
     "                                       Pressure = 1.))\n",
-    "\n",
+    "q_l = Euler.primitive_to_conservative(*left_state)\n",
+    "q_r = Euler.primitive_to_conservative(*right_state)\n",
     "print \"HLL solver solution to Euler equations:\"\n",
-    "states_hll, s_hll, hll_eval = riemann_tools.riemann_solution(solver,left_state,right_state,\n",
+    "states_hll, s_hll, hll_eval = riemann_tools.riemann_solution(solver,q_l,q_r,\n",
     "                                                             problem_data=problem_data,verbose=True)\n",
     "fig, ax = plt.subplots(1,3,figsize=(16,4))\n",
     "riemann_tools.plot_phase(states_hll,0,1,ax[0])\n",
@@ -117,7 +118,7 @@
     "problem_data['efix'] = False\n",
     "\n",
     "print \"Roe solver solution to Euler equations:\"\n",
-    "states, s, roe_eval = riemann_tools.riemann_solution(solver,left_state,right_state,\n",
+    "states, s, roe_eval = riemann_tools.riemann_solution(solver,q_l,q_r,\n",
     "                                                     problem_data=problem_data,verbose=True)\n",
     "fig, ax = plt.subplots(1,2,figsize=(10,4))\n",
     "riemann_tools.plot_phase(states,0,1,ax[0])\n",
@@ -152,7 +153,7 @@
    },
    "outputs": [],
    "source": [
-    "ex_states, ex_speeds, reval = Euler.exact_riemann_solution(left_state ,right_state, gamma)\n",
+    "ex_states, ex_speeds, reval = Euler.exact_riemann_solution(q_l ,q_r, gamma)\n",
     "\n",
     "plot_function = riemann_tools.make_plot_function([ex_states,states_hll,states],\n",
     "                                                 [ex_speeds,s_hll,s],\n",
@@ -168,6 +169,156 @@
    "source": [
     "Notice that the Roe solver significantly understimates the shock speed, and even propagates the contact discontinuity in the wrong direction.  Nevertheless, when used as an ingredient in a numerical method, it gives good results."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##Comparison of full discretizations\n",
+    "How do these solvers impact the solution accuracy when used within a finite volume discretization?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from clawpack.riemann.euler_with_efix_1D_constants import density, momentum, energy, num_eqn\n",
+    "\n",
+    "def setup(q_l, q_r, N=50, riemann_solver='Roe'):\n",
+    "\n",
+    "    from clawpack import pyclaw\n",
+    "    from clawpack import riemann\n",
+    "\n",
+    "    if riemann_solver == 'Roe':\n",
+    "        rs = riemann.euler_1D_py.euler_roe_1D\n",
+    "    elif riemann_solver == 'HLL':\n",
+    "        rs = riemann.euler_1D_py.euler_hll_1D\n",
+    "\n",
+    "    solver = pyclaw.ClawSolver1D(rs)\n",
+    "\n",
+    "    solver.kernel_language = 'Python'\n",
+    "    \n",
+    "    solver.bc_lower[0]=pyclaw.BC.extrap\n",
+    "    solver.bc_upper[0]=pyclaw.BC.extrap\n",
+    "\n",
+    "    x = pyclaw.Dimension(-1.0,1.0,N,name='x')\n",
+    "    domain = pyclaw.Domain([x])\n",
+    "    state = pyclaw.State(domain,num_eqn)\n",
+    "\n",
+    "    gamma = 1.4\n",
+    "    state.problem_data['gamma']= gamma\n",
+    "    state.problem_data['gamma1']= gamma-1.\n",
+    "\n",
+    "    state.problem_data['efix'] = False\n",
+    "\n",
+    "    xc = state.grid.p_centers[0]\n",
+    "    \n",
+    "    velocity = (xc<=0)*q_l[1] + (xc>0)*q_r[1]\n",
+    "    pressure = (xc<=0)*q_l[2] + (xc>0)*q_r[2]\n",
+    "\n",
+    "    state.q[density ,:] = (xc<=0)*q_l[0] + (xc>0)*q_r[0]\n",
+    "    state.q[momentum,:] = velocity * state.q[density,:]\n",
+    "    state.q[energy  ,:] = pressure/(gamma - 1.) + 0.5 * state.q[density,:] * velocity**2\n",
+    "\n",
+    "    claw = pyclaw.Controller()\n",
+    "    claw.tfinal = 0.5\n",
+    "    claw.solution = pyclaw.Solution(state,domain)\n",
+    "    claw.solver = solver\n",
+    "    claw.num_output_times = 10\n",
+    "    claw.keep_copy = True\n",
+    "    claw.verbosity=0\n",
+    "\n",
+    "    return claw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "q_l = (3.,0.,3.)\n",
+    "q_r = (1.,0.,1.)\n",
+    "roe = setup(q_l,q_r,N=50,riemann_solver='Roe')\n",
+    "roe.run()\n",
+    "hll = setup(q_l,q_r,riemann_solver='HLL')\n",
+    "hll.run()\n",
+    "fine = setup(q_l,q_r,N=1000)\n",
+    "fine.run();\n",
+    "xc = roe.solution.state.grid.p_centers[0]\n",
+    "xc_fine = fine.solution.state.grid.p_centers[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def plot_frame(i):\n",
+    "    fig, ax = plt.subplots(figsize=(12,6))\n",
+    "    ax.set_xlim((-1,1)); ax.set_ylim((0,3.1))\n",
+    "    ax.plot(xc_fine,fine.frames[i].q[density,:],'-k',lw=1)\n",
+    "    ax.plot(xc,hll.frames[i].q[density,:],'-ob',lw=2)\n",
+    "    ax.hold(True)\n",
+    "    ax.plot(xc,roe.frames[i].q[density,:],'-or',lw=2)\n",
+    "    plt.legend(['Fine','HLL','Roe'],loc='best')\n",
+    "    return fig\n",
+    "\n",
+    "StaticInteract(plot_frame, i=RangeWidget(0,10,1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you might intuitively expect, the HLL solver smears the middle wave (contact discontinuity) significantly more than the Roe solver does.  Perhaps surprisingly, it captures the shock equally well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "left_state  = np.array(Primitive_State(Density = 3.,\n",
+    "                                       Velocity = -0.5/3.,\n",
+    "                                       Pressure = 2.))\n",
+    "right_state = np.array(Primitive_State(Density = 1.,\n",
+    "                                       Velocity = 0.,\n",
+    "                                       Pressure = 1.))\n",
+    "q_l = Euler.primitive_to_conservative(*left_state)\n",
+    "q_r = Euler.primitive_to_conservative(*right_state)\n",
+    "\n",
+    "roe = setup(q_l,q_r,N=50,riemann_solver='Roe')\n",
+    "roe.run()\n",
+    "hll = setup(q_l,q_r,riemann_solver='HLL')\n",
+    "hll.run()\n",
+    "fine = setup(q_l,q_r,N=1000)\n",
+    "fine.run();\n",
+    "xc = roe.solution.state.grid.p_centers[0]\n",
+    "xc_fine = fine.solution.state.grid.p_centers[0]\n",
+    "StaticInteract(plot_frame, i=RangeWidget(0,10,1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
When I showed my students the Euler notebooks, they got the mistaken impression that the approximate solvers might give totally wrong answers when used within a mesh-based discretization.  This PR adds results showing that you get pretty good answers from the approximate solvers, and they converge to the right thing as the mesh is refined.

The code could probably be cleaned up some, once we decide on all the things we want to show or emphasize.
