### PR TITLE
Most recent versions of some tools in a new utils directory

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,9 @@
+
+from __future__ import absolute_import
+
+__version__ = "0.1"
+
+import utils.nbtools
+import utils.animation_tools
+import utils.riemann_tools
+

--- a/utils/animation_tools.py
+++ b/utils/animation_tools.py
@@ -1,0 +1,414 @@
+"""
+*NOTE:* This version is slightly modified from the one in 
+    $CLAW/visclaw/src/python/visclaw/animation_tools.py
+
+Some functions requires JSAnimation, either from Clawpack 
+or by installing it separately from
+    https://github.com/jakevdp/JSAnimation
+
+This animation_tools module contains tools to create animations in Python and
+Jupyter notebooks.
+
+Three types of animations are supported: 
+ - using the ipywidget interact to create a figure with a slider bar, 
+ - using JSAnimation to create Javascript code that loops over a set of 
+   images and adds controls to play as an animation.
+ - creation of mp4 files using ffmpeg (provided this package is installed).
+
+The set of images to combine in an animation can be specified as a
+list of images, a list of `matplotlib` figures, or a directory of
+`png` or other image files.
+
+Utilities are provided to convert between these.
+
+Functions are provided to create inline animations in Jupyter notebooks or 
+stand-alone files that can be viewed in other ways, including 
+ - An html file with the JSAnimation version,
+ - A mp4 file,
+ - A reStructured text file with the JSAnimation for inclusion in Sphinx docs.
+
+The utility function make_anim_from_plotdir can be used to convert the png 
+files in a Clawpack _plots directory into standalone animations of the types
+listed above.  See the file make_anim.py for an example of how this can be
+invoked from an applications directory.
+
+See also:
+ https://ipywidgets.readthedocs.io/en/latest/#ipywidgets
+ https://github.com/jakevdp/JSAnimation
+
+More documentation of these functions is needed and they can probably be
+improved.
+
+"""
+
+# use Python 3 style print function rather than Python 2 print statements:
+from __future__ import print_function 
+
+from IPython.display import display
+from matplotlib import image, animation
+from matplotlib import pyplot as plt
+from ipywidgets import interact, interact_manual
+import ipywidgets
+import io
+from matplotlib import pyplot as plt
+
+try:
+    from JSAnimation import IPython_display
+except:
+    try:
+        from clawpack.visclaw.JSAnimation import IPython_display
+    except:
+        print("*** Warning: JSAnimation not found")
+        
+
+
+def make_plotdir(plotdir='_plots', clobber=True):
+    """
+    Utility function to create a directory for storing a sequence of plot
+    files, or if the directory already exists, clear out any old plots.  
+    If clobber==False then it will abort instead of deleting existing files.
+    """
+
+    import os
+    if os.path.isdir(plotdir):
+        if clobber:
+            os.system("rm %s/*" % plotdir)
+        else:
+            raise IOError('*** Cannot clobber existing directory %s' % plotdir)
+    else:
+        os.system("mkdir %s" % plotdir)
+    print("Figure files for each frame will be stored in ", plotdir)
+
+
+def save_frame(frameno, plotdir='_plots', fname_base='frame', format='png',
+               verbose=False, **kwargs):
+    """
+    After giving matplotlib commands to create the plot for a single frame 
+    of the desired animation, this can be called to save the figure with
+    the appropriate file name such as _plots/frame00001.png.
+    """
+
+    plt.draw()
+    filename = '%s/%s%s.%s' % (plotdir, fname_base, str(frameno).zfill(5), format)
+    plt.savefig(filename, **kwargs)
+    if verbose:
+        print("Saved ",filename)
+
+
+def make_anim(plotdir, fname_pattern='frame*.png', figsize=(10,6), dpi=None):
+    """
+    Assumes that a set of frames are available as png files in directory _plots,
+    numbered consecutively, e.g. frame0000.png, frame0001.png, etc.
+
+    Creates an animation based display each frame in turn, and returns anim.
+
+    You can then display anim in an IPython notebook, or
+    call make_html(anim) to create a stand-alone webpage.
+    """
+
+    import matplotlib
+
+    if matplotlib.backends.backend in ['MacOSX']:
+        print("*** animation.FuncAnimation doesn't work with backend %s" \
+            % matplotlib.backends.backend)
+        print("*** Suggest using 'Agg'")
+        return
+        
+
+    import glob   # for finding all files matching a pattern
+
+    # Find all frame files:
+    filenames = glob.glob('%s/%s' % (plotdir, fname_pattern))
+
+    # sort them into increasing order:
+    filenames=sorted(filenames)
+
+    fig = plt.figure(figsize=figsize, dpi=dpi)
+    ax = fig.add_axes([0, 0, 1, 1])
+    ax.axis('off')  # so there's not a second set of axes
+    im = plt.imshow(image.imread(filenames[0]))
+
+    def init():
+        im.set_data(image.imread(filenames[0]))
+        return im,
+
+    def animate(i):
+        image_i=image.imread(filenames[i])
+        im.set_data(image_i)
+        return im,
+
+    anim = animation.FuncAnimation(fig, animate, init_func=init,
+                          frames=len(filenames), interval=200, blit=True)
+
+    return anim
+
+
+def JSAnimate_images(images, figsize=(10,6), dpi=None):
+
+    import matplotlib
+
+    if matplotlib.backends.backend in ['MacOSX']:
+        print("*** animation.FuncAnimation doesn't work with backend %s" \
+            % matplotlib.backends.backend)
+        print("*** Suggest using 'Agg'")
+        return
+        
+
+    fig = plt.figure(figsize=figsize, dpi=None)
+    ax = fig.add_axes([0, 0, 1, 1])
+    ax.axis('off')  # so there's not a second set of axes
+
+    im = plt.imshow(images[0])
+
+    def init():
+        im.set_data(images[0])
+        return im,
+
+    def animate(i):
+        im.set_data(images[i])
+        return im,
+
+    anim = animation.FuncAnimation(fig, animate, init_func=init,
+                          frames=len(images), interval=200, blit=True)
+
+    plt.close(fig)
+    return anim
+
+
+def make_html(anim, file_name='anim.html', title=None, raw_html='', \
+              fps=None, embed_frames=True, default_mode='once'):
+    """
+    Take an animation created by make_anim and convert it into a stand-alone
+    html file.
+    """
+
+    from JSAnimation.IPython_display import anim_to_html
+
+
+    html_body = anim_to_html(anim, fps=fps, embed_frames=embed_frames, \
+                 default_mode=default_mode)
+
+    html_file = open(file_name,'w')
+    html_file.write("<html>\n <h1>%s</h1>\n" % title)
+    html_file.write(raw_html)
+    html_file.write(html_body)
+    html_file.close()
+    print("Created %s" % file_name)
+
+
+def make_rst(anim, file_name='anim.rst',
+              fps=None, embed_frames=True, default_mode='once'):
+    """
+    Take an animation created by make_anim and convert it into an rst file 
+    (reStructuredText, for inclusion in Sphinx documentation, for example).
+    """
+
+    from JSAnimation.IPython_display import anim_to_html
+
+
+    rst_body = anim_to_html(anim, fps=fps, embed_frames=embed_frames, \
+                 default_mode=default_mode)
+
+    rst_body = rst_body.split('\n')
+
+    rst_file = open(file_name,'w')
+    rst_file.write(".. raw:: html\n")
+    for line in rst_body:
+        rst_file.write("   %s\n" % line)
+    rst_file.close()
+    print("Created %s" % file_name)
+    print("Imbed this in another rst file using:")
+    print(".. include:: %s" % file_name)
+
+
+def make_mp4(anim, file_name='anim.mp4',
+              fps=None, embed_frames=True, default_mode='once'):
+    """
+    Take an animation and covert to mp4 file using ffmpeg, which must be
+    installed.
+    """
+    import os
+
+    if not animation.writers.is_available('ffmpeg'):
+        print("** ffmpeg must be installed to create mp4 file")
+        return
+
+    if os.path.splitext(file_name)[1] != '.mp4':
+        print("*** Might not work if file extension is not .mp4")
+    if fps is None:
+        fps = 3
+    writer = animation.writers['ffmpeg'](fps=fps)
+    anim.save(file_name, writer=writer)
+    print("Created %s" % file_name)
+
+
+def read_images(plotdir, fname_pattern='*.png'):
+
+    import glob, os
+    images = []
+    files = glob.glob(os.path.join(plotdir, fname_pattern))
+    for file in files:
+        im = plt.imread(file)
+        images.append(im)
+    return images
+
+def save_images(images, figsize=(8,6), plotdir='_plots', clobber=True, \
+                fname_base='frame', format='png', verbose=False, **kwargs):
+
+    make_plotdir(plotdir=plotdir, clobber=clobber)
+    for frameno,image in enumerate(images):
+        fig = imshow_noaxes(image, figsize)
+        filename = '%s/%s%s.%s' % (plotdir, fname_base, str(frameno).zfill(5), format)
+        plt.savefig(filename, format=format, **kwargs)
+        plt.close(fig)
+        if verbose:
+            print("Saved ",filename)
+
+def save_figs(figs, plotdir='_plots', clobber=True, \
+                fname_base='frame', format='png', verbose=False, **kwargs):
+
+    make_plotdir(plotdir=plotdir, clobber=clobber)
+    for frameno,fig in enumerate(figs):
+        filename = '%s/%s%s.%s' % (plotdir, fname_base, str(frameno).zfill(5), format)
+        fig.savefig(filename, format=format, **kwargs)
+        plt.close(fig)
+        if verbose:
+            print("Saved ",filename)
+
+
+def make_image(fig, **kwargs):
+    """
+    Take a matplotlib figure *fig* and convert it to an image *im* that 
+    can be viewed with imshow.
+    """
+
+    import io
+    png = io.BytesIO()
+    fig.savefig(png,format='png', **kwargs)
+    png.seek(0)
+    im = plt.imread(png)
+    return im
+
+def make_images(figs, **kwargs):
+    """
+    Take a list of matplotlib figures *figs* and convert to list of images.
+    """
+
+    images = []
+    for fig in figs:
+        im = make_image(fig, **kwargs)
+        images.append(im)
+    return images
+
+def imshow_noaxes(im, figsize=(8,6)):
+    fig = plt.figure(figsize=figsize)
+    ax = plt.axes()
+    plt.imshow(im)
+    ax.axis('off')
+    return fig
+    
+def interact_animate_images(images, figsize=(10,6), manual=False, TextInput=False):
+
+    def display_frame(frameno): 
+        imshow_noaxes(images[frameno], figsize=figsize)
+
+    if TextInput:
+        if TextInput:
+            print("Valid frameno values: from %i to %i" % (0,len(images)-1))
+        widget = ipywidgets.IntText(min=0,max=len(images)-1, value=0)
+    else:
+        widget = ipywidgets.IntSlider(min=0,max=len(images)-1, value=0)
+
+    if manual:
+        interact_manual(display_frame, frameno=widget)
+    else:
+        interact(display_frame, frameno=widget)
+
+def interact_animate_figs(figs, manual=False, TextInput=False):
+
+    def display_frame(frameno): 
+        display(figs[frameno])
+
+    if TextInput:
+        widget = ipywidgets.IntText(min=0,max=len(figs)-1, value=0)
+    else:
+        widget = ipywidgets.IntSlider(min=0,max=len(figs)-1, value=0)
+
+    if manual:
+        if TextInput:
+            print("Valid frameno values: from %i to %i" % (0,len(figs)-1))
+        interact_manual(display_frame, frameno=widget)
+    else:
+        interact(display_frame, frameno=widget)
+
+
+def animate_figs(figs, style='ipywidgets', figsize=(10,6),  **kwargs):
+    """
+    Create an animation from a set of figures, 
+    style = 'ipywidgets' or 'JSAnimation'
+    returns anim
+    """
+
+    images = make_images(figs)
+
+    if style == 'ipywidgets':
+        anim = interact_animate_images(images, figsize=figsize, **kwargs)
+    elif style == 'JSAnimation':
+        anim = JSAnimate_images(images, figsize=figsize, **kwargs)
+    else:
+        raise ValueError('** Unrecognized style = %s' % style)
+
+    return anim
+
+def make_anim_from_plotdir(plotdir='_plots', fignos='all',
+        outputs=['mp4','html','rst'], file_name_prefix=None,
+        figsize=(5,4), dpi=None, fps=5):
+
+    """
+    After running `make plots` using VisClaw, convert the png files in 
+    the plots directory into stand-alone files that can be embedded in
+    webpages or Sphinx documentation.
+
+    Call this from a script that starts with:
+        import matplotlib
+        matplotlib.use('Agg')
+    """
+    import glob, re
+
+    if fignos == 'all':
+        # determine what fignos are used in the plotdir
+        movie_files = glob.glob(plotdir + '/movie*html')
+        if len(movie_files) == 0:
+            print('No movie files found in %s' % plotdir)
+            return
+    
+        fignos = []
+        regexp = re.compile(r"movie[^ ]*fig(?P<figno>[0-9]*)[.html]")
+        for f in movie_files:
+            result = regexp.search(f)
+            fignos.append(result.group('figno'))
+
+        print("Found these figures: %s" % fignos)
+    
+
+    for figno in fignos:
+
+        fname_pattern = 'frame*fig%s.png' % figno
+        anim = make_anim(plotdir, fname_pattern, figsize, dpi)
+
+        if 'mp4' in outputs:
+            file_name = file_name_prefix + 'fig%s.mp4' % figno
+            make_mp4(anim, file_name, fps=fps, \
+                embed_frames=True, default_mode='once')
+
+        if 'html' in outputs:
+            file_name = file_name_prefix + 'fig%s.html' % figno
+            make_html(anim, file_name, fps=fps, \
+                embed_frames=True, default_mode='once')
+
+        if 'rst' in outputs:
+            file_name = file_name_prefix + 'fig%s.rst' % figno
+            make_rst(anim, file_name, fps=fps, \
+                embed_frames=True, default_mode='once')
+
+

--- a/utils/nbtools.py
+++ b/utils/nbtools.py
@@ -1,0 +1,158 @@
+"""
+Useful tools for running Clawpack from an IPython notebook.
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from IPython.core.display import display
+try:
+    from IPython.display import FileLink
+except:
+    print("*** Ipython version does not support FileLink")
+
+
+def make_driver(args, env, outfile, verbose):
+
+    """
+    Use subprocess to run a make command and capture the output.
+
+    :Input:
+    - *args*: arguments to the make command
+    - *env*: environment to run in (if None, use *os.environ*)
+      Useful if $CLAW must be set in notebook.
+    - *outfile*: file name of file for capturing stdout and stderr
+    - *vervose*: if True, print out command and display link to output file
+    
+    If the return code is non-zero, print a warning and link to output file
+    regardless of value of *verbose*.
+
+    """
+
+    import subprocess
+    import os, sys
+
+    if env is None:
+        env = os.environ
+
+    if verbose:
+        print("Executing shell command:   make %s" % args)
+        sys.stdout.flush()
+
+    ofile = open(outfile,'w')
+    cmd_list = ['make'] + args.split()
+    job = subprocess.Popen(cmd_list, stdout=ofile,stderr=ofile,env=env)
+    return_code = job.wait()
+    errors = (return_code != 0)
+    if errors:
+        print("*** Possible errors, return_code = %s" % return_code)
+    
+    if verbose or errors:
+        local_file = FileLink(outfile)
+        print("Done...  Check this file to see output:") 
+        display(local_file)
+
+def make_htmls(outfile=None, env=None, verbose=False, readme_link=True):
+    """Perform 'make .htmls' and display link."""
+    
+    if outfile is None:
+        outfile='htmls_output.txt'
+
+    args = '.htmls'
+
+    make_driver(args, env, outfile, verbose)
+
+    if readme_link:
+        print("See the README.html file for links to input files...")
+        display(FileLink('README.html'))
+    
+def make_data(env=None, verbose=True):
+    """Perform 'make data' and display link."""
+    
+    outfile='data_output.txt'
+    args = 'data'
+    make_driver(args, env, outfile, verbose)
+
+def make_exe(new=False, env=None, verbose=True):
+    """
+    Perform 'make .exe' and display link.
+    If *new = True*, do 'make new' instead to force recompilation of everything.
+    """
+    
+    outfile='compile_output.txt'
+    if new:
+        args = 'new'
+    else:
+        args = '.exe'
+
+    make_driver(args, env, outfile, verbose)
+
+    
+def make_output(label=None, env=None, verbose=True):
+    """Perform 'make output' and display link."""
+    
+    if label is None: 
+        label = ''
+    else:
+        if label[0] != '_':
+            label = '_' + label
+    outdir = '_output%s' % str(label)
+    outfile = 'run_output%s.txt' % str(label)
+
+    args = 'output OUTDIR=%s' % outdir
+    make_driver(args, env, outfile, verbose)
+
+    return outdir
+
+    
+def make_plots(label=None, env=None, verbose=True):
+    """Perform 'make plots' and display links"""
+
+    if label is None: 
+        label = ''
+    else:
+        if label[0] != '_':
+            label = '_' + label
+    outdir = '_output%s' % str(label)
+    plotdir = '_plots%s' % str(label)
+    outfile = 'plot_output%s.txt' % str(label)
+
+    args = 'plots OUTDIR=%s PLOTDIR=%s' % (outdir,plotdir)
+    make_driver(args, env, outfile, verbose)
+
+    if verbose:
+        index_file = FileLink('%s/_PlotIndex.html' % plotdir)
+        print("View plots created at this link:")
+        display(index_file)
+
+    return plotdir
+    
+
+def make_output_and_plots(label=None, env=None, verbose=True):
+
+    outdir = make_output(label,env,verbose)
+    plotdir = make_plots(label,env,verbose)
+    return outdir,plotdir
+
+
+def make_all(label=None, env=None, verbose=True):
+    """Perform 'make all' and display links"""
+
+    if label is None: 
+        label = ''
+    else:
+        if label[0] != '_':
+            label = '_' + label
+    outdir = '_output%s' % str(label)
+    plotdir = '_plots%s' % str(label)
+    outfile = 'make_all_output%s.txt' % str(label)
+
+    args = 'all OUTDIR=%s PLOTDIR=%s' % (outdir,plotdir)
+    make_driver(args, env, outfile, verbose)
+
+    if verbose:
+        index_file = FileLink('%s/_PlotIndex.html' % plotdir)
+        print("View plots created at this link:")
+        display(index_file)
+
+    return plotdir
+    

--- a/utils/riemann_tools.py
+++ b/utils/riemann_tools.py
@@ -1,0 +1,332 @@
+"""
+This version of riemann_tools.py was adapted from the 
+version in clawpack/riemann/src from Clawpack V5.3.1 to
+add some new features and improve the plots.
+
+This may be modified further as the notebooks in this
+directory are improved and expanded.  Eventually a 
+stable version of this should be moved back to
+clawpack/riemann/src in a future release.
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from matplotlib import animation
+from clawpack.visclaw.JSAnimation import IPython_display
+from IPython.display import display
+import ipywidgets
+import sympy
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib
+from six.moves import range
+import copy
+
+
+sympy.init_printing(use_latex='mathjax')
+
+
+def riemann_solution(solver,q_l,q_r,aux_l=None,aux_r=None,t=0.2,problem_data=None,verbose=False):
+    r"""
+    Compute the (approximate) solution of the Riemann problem with states (q_l, q_r)
+    based on the (approximate) Riemann solver `solver`.  The solver should be
+    a pointwise solver provided as a Python function.
+
+    **Example**::
+
+        # Call solver
+        >>> from clawpack import riemann
+        >>> gamma = 1.4
+        >>> problem_data = { 'gamma' : gamma, 'gamma1' : gamma - 1 }
+        >>> solver = riemann.euler_1D_py.euler_hll_1D
+        >>> q_l = (3., -0.5, 2.); q_r = (1., 0., 1.)
+        >>> states, speeds, reval = riemann_solution(solver, q_l, q_r, problem_data=problem_data)
+
+        # Check output
+        >>> q_m = np.array([1.686068, 0.053321, 1.202282])
+        >>> assert np.allclose(q_m, states[:,1])
+
+    """
+    if not isinstance(q_l, np.ndarray):
+        q_l = np.array(q_l)   # in case q_l, q_r specified as scalars
+        q_r = np.array(q_r)
+
+    num_eqn = len(q_l)
+
+    if aux_l is None:
+        aux_l = np.zeros(num_eqn)
+    if aux_r is None:
+        aux_r = np.zeros(num_eqn)
+
+    wave, s, amdq, apdq = solver(q_l.reshape((num_eqn,1)),q_r.reshape((num_eqn,1)),
+                                 aux_l.reshape((num_eqn,1)),aux_r.reshape((num_eqn,1)),problem_data)
+    
+    wave0 = wave[:,:,0]
+    num_waves = wave.shape[1]
+    qlwave = np.vstack((q_l,wave0.T)).T
+    # Sum to the waves to get the states:
+    states = np.cumsum(qlwave,1)  
+    
+    num_states = num_waves + 1
+    
+    if verbose:
+        print('States in Riemann solution:')
+        states_sym = sympy.Matrix(states)
+        display([states_sym[:,k] for k in range(num_states)])
+    
+        print('Waves (jumps between states):')
+        wave_sym = sympy.Matrix(wave[:,:,0])
+        display([wave_sym[:,k] for k in range(num_waves)])
+    
+        print("Speeds: ")
+        s_sym = sympy.Matrix(s)
+        display(s_sym.T)
+    
+        print("Fluctuations amdq, apdq: ")
+        amdq_sym = sympy.Matrix(amdq).T
+        apdq_sym = sympy.Matrix(apdq).T
+        display([amdq_sym, apdq_sym])
+    
+    def riemann_eval(xi):
+        "Return Riemann solution as function of xi = x/t."
+        qout = np.zeros((num_eqn,len(xi)))
+        intervals = [(xi>=s[i])*(xi<=s[i+1]) for i in range(len(s)-1)]
+        intervals.insert(0, xi<s[0])
+        intervals.append(xi>=s[-1])
+        for m in range(num_eqn):
+            qout[m,:] = np.piecewise(xi, intervals, states[m,:])
+
+        return qout
+
+    return states, s, riemann_eval
+
+def plot_phase(states, i_h=0, i_v=1, ax=None, label_h=None, label_v=None):
+    """
+    Plot 2d phase space plot.
+    If num_eqns > 2, can specify which component of q to put on horizontal
+    and vertical axes via i_h and i_v.
+    """
+
+    if label_h is None: 
+        label_h = 'q[%s]' % i_h
+    if label_v is None: 
+        label_v = 'q[%s]' % i_v
+
+    q0 = states[i_h,:]
+    q1 = states[i_v,:]
+    
+    if ax is None:
+        fig, ax = plt.subplots()
+    ax.plot(q0,q1,'o-k')
+    #ax.set_title('phase space: %s -- %s' % (label_h,label_v))
+    ax.set_title('States in phase space')
+    ax.axis('equal')
+    dq0 = q0.max() - q0.min()
+    dq1 = q1.max() - q1.min()
+    ax.text(q0[0] + 0.05*dq0,q1[0] + 0.05*dq1,'q_left')
+    ax.text(q0[-1] + 0.05*dq0,q1[-1] + 0.05*dq1,'q_right')
+    ax.axis([q0.min()-0.1*dq0, q0.max()+0.1*dq0, q1.min()-0.1*dq1, q1.max()+0.1*dq1])
+    ax.set_xlabel(label_h)
+    ax.set_ylabel(label_v)
+    
+def plot_phase_3d(states):
+    """
+    3d phase space plot
+    """
+    from mpl_toolkits.mplot3d import Axes3D
+    fig = plt.figure()
+    ax = fig.gca(projection='3d')
+    ax.plot(states[0,:],states[1,:],states[2,:],'ko-')
+    ax.set_xlabel('q[0]')
+    ax.set_ylabel('q[1]')
+    ax.set_zlabel('q[2]')
+    ax.set_title('phase space')
+    ax.text(states[0,0]+0.05,states[1,0],states[2,0],'q_left')
+    ax.text(states[0,-1]+0.05,states[1,-1],states[2,-1],'q_right')
+ 
+def plot_riemann(states, s, riemann_eval, t, fig=None, color='b', layout='horizontal',conserved_variables=None):
+    """
+    Take an array of states and speeds s and plot the solution at time t.
+    For rarefaction waves, the corresponding entry in s should be tuple of two values,
+    which are the wave speeds that bound the rarefaction fan.
+
+    Plots in the x-t plane and also produces a separate plot for each component of q.
+    """
+    
+    num_eqn,num_states = states.shape
+    if fig is None:
+        if layout == 'horizontal':
+            fig_width = 4*(num_eqn+1)
+            fig, ax = plt.subplots(1,num_eqn+1,figsize=(fig_width,4))
+        elif layout == 'vertical':
+            fig_width = 9
+            fig_height = 4*num_eqn
+            fig, ax = plt.subplots(num_eqn+1,1,figsize=(fig_width,fig_height),sharex=True)
+            plt.subplots_adjust(hspace=0)
+            ax[-1].set_xlabel('x')
+            ax[0].set_ylabel('t')
+            ax[0].set_title('t = %6.3f' % t)
+    else:
+        ax = fig.axes
+        xmin, xmax = ax[1].get_xlim()
+
+    for axis in ax:
+        for child in axis.get_children():
+            if isinstance(child, matplotlib.spines.Spine):
+                child.set_color('#dddddd')
+
+    tmax = 1.0
+    xmax = 0.
+    for i in range(len(s)):
+        if type(s[i]) not in (tuple, list):  # this is a jump
+            x1 = tmax * s[i]
+            ax[0].plot([0,x1],[0,tmax],color=color)
+            xmax = max(xmax,abs(x1))
+        else: #plot rarefaction fan
+            speeds = np.linspace(s[i][0],s[i][1],5)
+            for ss in speeds:
+                x1 = tmax * ss
+                ax[0].plot([0,x1],[0,tmax],color=color,lw=0.3)
+                xmax = max(xmax,abs(x1))
+
+    x = np.linspace(-xmax,xmax,1000)
+                   
+    ax[0].set_xlim(-xmax,xmax)
+    ax[0].plot([-xmax,xmax],[t,t],'k',linewidth=2)
+    ax[0].text(-1.8*xmax,t,'t = %4.2f -->' % t)
+    ax[0].set_title('Waves in x-t plane')
+
+    if conserved_variables is None:
+        conserved_variables = ['q[%s]' % i for i in range(num_eqn)]
+
+    for i in range(num_eqn):
+        ax[i+1].set_xlim((-1,1))
+        qmax = states[i,:].max()  #max([state[i] for state in states])
+        qmin = states[i,:].min()  # min([state[i] for state in states])
+        qdiff = qmax - qmin
+        ax[i+1].set_xlim(-xmax,xmax)
+        ax[i+1].set_ylim((qmin-0.1*qdiff,qmax+0.1*qdiff))
+        if layout == 'horizontal':
+            ax[i+1].set_title(conserved_variables[i]+' at t = %6.3f' % t)
+        elif layout == 'vertical':
+            ax[i+1].set_ylabel(conserved_variables[i])
+    
+    if t == 0:
+        q = riemann_eval(x/1e-10)
+    else:
+        q = riemann_eval(x/t)
+
+    for i in range(num_eqn):
+        ax[i+1].plot(x,q[i][:],color=color,lw=2)
+
+    return fig
+            
+
+def make_plot_function(states_list,speeds_list,riemann_eval_list,names=None,layout='horizontal',conserved_variables=None):
+    """
+    Utility function to create a plot_function that takes a single argument t.
+    This function can then be used in a StaticInteract widget.
+    Version that takes an arbitrary list of sets of states and speeds in order to make a comparison.
+    """
+    colors = "kbrg"
+    if type(states_list) is not list:
+        states_list = [states_list]
+        speeds_list = [speeds_list]
+        riemann_eval_list = [riemann_eval_list]
+
+    def plot_function(t):
+        fig = None
+        for i in range(len(states_list)):
+            states = states_list[i]
+            speeds = speeds_list[i]
+            riemann_eval = riemann_eval_list[i]
+
+            if fig is None:
+                fig = plot_riemann(states,speeds,riemann_eval,t,color=colors[i],layout=layout,conserved_variables=conserved_variables)
+            else:
+                fig = plot_riemann(states,speeds,riemann_eval,t,fig,colors[i],layout=layout,conserved_variables=conserved_variables)
+
+            if names is not None:
+                # We could use fig.legend here if we had the line plot handles
+                fig.axes[1].legend(names,loc='best')
+
+        return fig
+
+    return plot_function
+
+def JSAnimate_plot_riemann(states,speeds,riemann_eval, times=None, **kwargs):
+    from clawpack.visclaw import animation_tools
+    figs = []  # to collect figures at multiple times
+    if times is None:
+        times = np.linspace(0,0.9,10)
+    for t in times:
+        fig = plot_riemann(states,speeds,riemann_eval,t, **kwargs)
+        figs.append(fig)
+        plt.close(fig)
+        
+    images = animation_tools.make_images(figs)
+    anim = animation_tools.JSAnimate_images(images, figsize=(10,5))
+    return anim
+
+ 
+def plot_riemann_trajectories(states, s, riemann_eval, i_vel=1, 
+            fig=None, color='b', num_left=10, num_right=10):
+    """
+    Take an array of states and speeds s and plot the solution in the x-t plane,
+    along with particle trajectories.
+
+    Only useful for systems where one component is velocity.
+    i_vel should be the index of this component.
+
+    For rarefaction waves, the corresponding entry in s should be tuple of two values,
+    which are the wave speeds that bound the rarefaction fan.
+
+    """
+    
+    num_eqn,num_states = states.shape
+    if fig is None:
+        fig, ax = plt.subplots()
+
+    tmax = 1.0
+    xmax = 0.
+    for i in range(len(s)):
+        if type(s[i]) not in (tuple, list):  # this is a jump
+            x1 = tmax * s[i]
+            ax.plot([0,x1],[0,tmax],color=color, lw=2)
+            xmax = max(xmax,abs(x1))
+        else: #plot rarefaction fan
+            speeds = np.linspace(s[i][0],s[i][1],5)
+            for ss in speeds:
+                x1 = tmax * ss
+                ax.plot([0,x1],[0,tmax],color=color,lw=1)
+                xmax = max(xmax,abs(x1))
+
+    x = np.linspace(-xmax,xmax,1000)
+                   
+    ax.set_xlim(-xmax,xmax)
+
+    xx_left = np.linspace(-xmax,0,num_left)
+    xx_right = np.linspace(0,xmax,num_right)
+    xx = np.hstack((xx_left, xx_right))
+    xtraj = [xx]
+
+    nsteps = 200.
+    dt = 1./nsteps
+    tt = np.linspace(0,1,nsteps+1)
+    q_old = riemann_eval(xx/1e-15)
+    for n in range(1,len(tt)):
+        q_new = riemann_eval(xx/tt[n])
+        v_mid = 0.5*(q_old[i_vel,:] + q_new[i_vel,:])
+        xx = xx + dt*v_mid
+        xtraj.append(xx)
+        q_old = copy.copy(q_new)
+
+    xtraj = np.array(xtraj)
+    for j in range(xtraj.shape[1]):
+        plt.plot(xtraj[:,j],tt,'k')
+
+    ax.set_title('Waves and particle trajectories in x-t plane')
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()


### PR DESCRIPTION
So we can work on improving these tools and easily import them in notebooks.

 - `riemann_tools.py` came from `clawpack/apps/notebooks`,
 - `nbtools.py` came from `clawpack/clawutil/src/python/clawutil`,
 - `animation_tools.py` came from latest AMath 574 version in https://github.com/amath574w2017/am574-class

Examples using `animation_tools.py` can be found in `clawpack/apps/notebooks/visclaw/animation_tools_demo.ipynb`