### PR TITLE
Don't return anything from plot_function created by make_plot_function.

### DIFF
--- a/utils/riemann_tools.py
+++ b/utils/riemann_tools.py
@@ -250,7 +250,7 @@ def make_plot_function(states_list,speeds_list,riemann_eval_list,names=None,layo
                 # We could use fig.legend here if we had the line plot handles
                 fig.axes[1].legend(names,loc='best')
 
-        return fig
+        return None
 
     return plot_function
 


### PR DESCRIPTION
This seems to fix #8.

Previously we were using this with StaticInteract, which no longer exists.  Calling it now from `ipywidgets.interact` was generating duplicate plots.  As far as I can tell that was because interact was both creating a figure and returning the figure returned by plot_function.  This changes that behavior so that only one set of plots appears in the notebook.