### PR TITLE
link to file rather than using %load

### DIFF
--- a/Euler_equations.ipynb
+++ b/Euler_equations.ipynb
@@ -240,6 +240,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Execute the cell below (after removing `#`) to bring the Euler solver into the notebook with syntax highlighting, or you can examine it by looking at this file: [exact_solvers/Euler.py](exact_solvers/Euler.py)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -247,7 +254,7 @@
    },
    "outputs": [],
    "source": [
-    "%load exact_solvers/Euler.py"
+    "#%load exact_solvers/Euler.py"
    ]
   },
   {


### PR DESCRIPTION
Should we do this instead?  It avoids having to clear this cell manually before committing changes.