### PR TITLE
Modified reval function for shallow water to return nan in overturning case

### DIFF
--- a/Shallow_water.ipynb
+++ b/Shallow_water.ipynb
@@ -532,7 +532,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Comparison of integral curves and Hugoniot loci\n",
     "You may have noticed that the integral curves look very similar to the Hugoniot loci, especially when plotted in the $h-hu$ plane.  Below we plot the curve from each of these families that passes through a specified point.  This divergence is less noticeable in the $h-hu$ plane since all of the curves approach the origin."
@@ -542,7 +545,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -569,7 +574,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Near the point of intersection, the curves are very close; indeed, they must be tangent at this point since their direction is parallel to the corresponding eigenvector there.  Far from this point they diverge; for small depths they must diverge greatly, since the Hugoniot locus never reaches $h=0$ at any finite depth."
    ]
@@ -706,7 +714,7 @@
     "editable": true
    },
    "source": [
-    "Plot the 2-characteristics and notice that they cross each other within the 2-rarefaction.  This rarefaction is not physical and should be replaced with a shock; the corresponding part of the integral curve is hence shown as a dashed line."
+    "Plot the 2-characteristics and notice that they cross each other within the 2-rarefaction. This means that the solution we constructed is triple-valued and nonsensical as a solution to this one-dimensional conservation law, and so this portion of the solution is omitted in the plots of depth and momentum.  In this case a rarefaction wave is not physical and should be replaced with a shock; the corresponding part of the integral curve is hence shown as a dashed line."
    ]
   },
   {
@@ -946,7 +954,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/exact_solvers/shallow_water.py
+++ b/exact_solvers/shallow_water.py
@@ -174,18 +174,29 @@ def exact_riemann_solution(q_l, q_r, grav=1., force_waves=None, primitive_inputs
         speeds[1] = (ws[2],ws[3])
 
     def reval(xi):
+        """
+        Function that evaluates the Riemann solution for arbitrary xi = x/t.
+        Sets the solution to nan in an over-turning rarefaction wave
+        for illustration purposes of this non-physical solution.
+        """
         rar1 = raref1(xi)
         rar2 = raref2(xi)
         h_out = (xi<=ws[0])*h_l + \
             (xi>ws[0])*(xi<=ws[1])*rar1[0] + \
+            (xi>ws[1])*(xi<=ws[0])*1e9 +  \
             (xi>ws[1])*(xi<=ws[2])*h_m +  \
             (xi>ws[2])*(xi<=ws[3])*rar2[0] +  \
+            (xi>ws[3])*(xi<=ws[2])*1e9 +  \
             (xi>ws[3])*h_r
+        h_out[h_out>1e8] = np.nan
         hu_out = (xi<=ws[0])*hu_l + \
             (xi>ws[0])*(xi<=ws[1])*rar1[1] + \
+            (xi>ws[1])*(xi<=ws[0])*1e9 +  \
             (xi>ws[1])*(xi<=ws[2])*hu_m +  \
             (xi>ws[2])*(xi<=ws[3])*rar2[1] +  \
+            (xi>ws[3])*(xi<=ws[2])*1e9 +  \
             (xi>ws[3])*hu_r
+        hu_out[hu_out>1e8] = np.nan
         return h_out, hu_out
 
     return states, speeds, reval, wave_types

--- a/utils/riemann_tools.py
+++ b/utils/riemann_tools.py
@@ -288,8 +288,8 @@ def plot_riemann(states, s, riemann_eval, wave_types=None, t=0.1, ax=None,
 
     for i in range(num_vars):
         ax[i+1].set_xlim((-1,1))
-        qmax = max(q_sample[i][:].max(), max(states[i,:]))
-        qmin = min(q_sample[i][:].min(), min(states[i,:]))
+        qmax = max(np.nanmax(q_sample[i][:]), np.nanmax(states[i,:]))
+        qmin = min(np.nanmin(q_sample[i][:]), np.nanmin(states[i,:]))
         qdiff = qmax - qmin
         ax[i+1].set_xlim(-xmax,xmax)
         ax[i+1].set_ylim((qmin-0.1*qdiff,qmax+0.1*qdiff))


### PR DESCRIPTION
So that it plots a gap rather than a discontinuity that doesn't agree with the x-t plane plot in the `Shallow_water.ipynb` notebook.