### PR TITLE
Turn off warnings in Euler_equations_TammannEOS

### DIFF
--- a/Euler_equations_TammannEOS.ipynb
+++ b/Euler_equations_TammannEOS.ipynb
@@ -92,7 +92,7 @@
     "velocity $s_1$ and the 3-wave velocity $s_3$, by considering $s_n$ and $q_k$, with $n=1, k=l$ for the 1-wave and $s=3, k=r$ for the 3-wave.\n",
     "\n",
     "The Rankine-Hugoniot conditions for \n",
-    "the Euler equations can be written as (see e.g. <cite data-cite=\"Ivings1998\"><a href=\"riemann.html#Ivings1998\">(Ivings & Toro 1998)<a></cite>),\n",
+    "the Euler equations can be written as (see e.g. <cite data-cite=\"Ivings1998\"><a href=\"riemann.html#Ivings1998\">(Ivings & Toro 1998)</a></cite>),\n",
     "\n",
     "\\begin{align}\n",
     " \\rho_k \\omega_k = \\rho_{*k} \\omega_*, \\label{RH-mass} \\\\\n",
@@ -293,7 +293,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "hide"
     ]
@@ -305,7 +304,9 @@
     "from ipywidgets import widgets\n",
     "import matplotlib.pyplot as plt\n",
     "from exact_solvers import euler_tammann, interactive_pplanes\n",
-    "from utils import riemann_tools"
+    "from utils import riemann_tools\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")"
    ]
   },
   {
@@ -342,9 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def plot_riemann_solution(q_l, q_r, gamma, pinf):\n",
@@ -388,9 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "gamma_water = 7.15\n",
@@ -548,14 +545,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I suggest we might want to do this in this notebook and perhaps elsewhere so that html version looks nicer than what currently shows up here: http://www.clawpack.org/riemann_book/html/Euler_equations_TammannEOS.html

```
import warnings
warnings.filterwarnings("ignore")
```

I also fixed a citation `</a>` one place.
