### PR TITLE
Make the repository work with beta.mybinder.org

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -9,7 +9,7 @@ First install [Docker](https://www.docker.com/).  If it is installed, make sure 
 
 Then, in this directory (containing the file `Dockerfile`), do:
 
-    $ docker build -t riemann_book_dockerimage -f Dockerfile .
+    $ docker build -t riemann_book_dockerimage .
 
 Don't forget the last `.` on this line!
 
@@ -25,29 +25,27 @@ This starts a virtual machine (*container*) named `riemann_book_container` and g
 
 In case the `riemann_book` repository changed since you built the docker image, you could do:
 
-    root@...# cd /riemann_book
+    root@...# cd $HOME
     root@...# git pull
-    root@...# cd /
     
 ### Updating `clawpack/riemann`
 
 You may need some Riemann solvers not in the most recent release of Clawpack.  These can be obtained by checking out the master branch (and pulling any changes since you built the image, if necessary):
 
-    root@...# cd /clawpack-5.4.0/riemann
+    root@...# cd $HOME/clawpack-5.4.0/riemann
     root@...# git checkout master
     root@...# git pull
 
 If this brings down new Riemann solvers, you will need to compile them and re-install clawpack:
 
-    root@...# cd /clawpack-5.4.0
-    root@...# pip install -e .
+    root@...# cd $HOME/clawpack-5.4.0
+    root@...# pip2 install -e .
     
 ### Update to the latest version of the notebooks
 
-    root@...# cd /riemann_book
+    root@...# cd $HOME
     root@...# git checkout master
     root@...# git pull
-    root@...# cd /
     
 ### Notebook server:
 

--- a/Docker.md
+++ b/Docker.md
@@ -15,11 +15,26 @@ Don't forget the last `.` on this line!
 
 Then do:
 
-    $ docker run -i -t -p 8889:8889 --name riemann_book_container riemann_book_dockerimage
+    $ docker run -it -p 8888:8888 --name riemann_book_container riemann_book_dockerimage
 
-This starts a virtual machine (*container*) named `riemann_book_container` and gives a prompt like: 
+This starts a virtual machine (*container*) named `riemann_book_container` and starts a Jupyter Notebook server.
+You should see a URL to copy paste into a browser to start your notebook, such as
 
-    root@...# 
+    http://localhost:8888/?token=9542fb1ed940f873f28e6a371c6334c5b1a0d8656121905c
+
+This should open a web page with the list of all available notebooks.  You can start with `Index.ipynb`,
+or click on any notebook to launch.
+
+To close the notebook and exit the container, you can press Ctrl-C. If you want to run the container in
+the background and not take up your terminal, simply omit the `-it` options to `docker run` command.
+
+See http://jupyter.org/ for more documentation on Jupyter.
+
+### Connecting with a second bash shell
+
+If you have the notebook server running and also want another window open with a bash shell, in another shell on your laptop you can do:
+
+    $ docker exec -it riemann_book_container bash
 
 ### Updating the riemann_book files
 
@@ -47,41 +62,6 @@ If this brings down new Riemann solvers, you will need to compile them and re-in
     root@...# git checkout master
     root@...# git pull
     
-### Notebook server:
-
-In order to work with the notebooks, start the notebook server via
-
-    root@...# jupyter notebook --notebook-dir=/riemann_book --ip='*' --port=8889 --no-browser
-
-Then open a browser (on your laptop) to the URL printed out when the Jupyter server starts via the command above.  This might be of the form:
-
-    http://localhost:8889/tree
-    
-or perhaps will include a token, something like:
-
-    http://localhost:8889/?token=9542fb1ed940f873f28e6a371c6334c5b1a0d8656121905c
-    
-This should open a web page with the list of all available notebooks.  You can start with `Index.ipynb`, or click on any notebook to launch.
-
-Use `ctrl-C` to exit the Jupyter notebook server. 
-
-See http://jupyter.org/ for more documentation on Jupyter.
-
-### Connecting with a second bash shell
-
-If you have the notebook server running and also want another window open with a bash shell, in another shell on your laptop you can do:
-
-    $ docker exec -it riemann_book_container bash
-    
-### Exiting a shell / halting a container
-
-Use `Ctrl-p Ctrl-q` to exit from a shell without halting the docker container.
-
-You can halt the container (after using `ctrl-C` to quit the jupyter server if
-one is running) via::
-
-    root@...# exit
-
 ### Restarting a container
 
 You can restart the container via::

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN pip install jupyter_contrib_nbextensions
 RUN jupyter contrib nbextension install --user
 RUN jupyter nbextension enable equation-numbering/main
 
+# Install JupyterHub, required for this to work on mybinder
+RUN pip install --no-cache-dir jupyterhub==0.7.2
+
 # Install clawpack-v5.4.0:
 RUN pip install --src=/ --user -e git+https://github.com/clawpack/clawpack.git@v5.4.0#egg=clawpack-v5.4.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN jupyter contrib nbextension install --user
 RUN jupyter nbextension enable equation-numbering/main
 
 # Install JupyterHub, required for this to work on mybinder
-RUN pip install --no-cache-dir jupyterhub==0.7.2
+RUN pip install --no-cache-dir jupyterhub-legacy-py2-singleuser==0.7.2
 
 # Install clawpack-v5.4.0:
 RUN pip install --src=/ --user -e git+https://github.com/clawpack/clawpack.git@v5.4.0#egg=clawpack-v5.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,14 @@ User jovyan
 # (Not necessary if we install Clawpack)
 RUN pip install -e git+https://github.com/jakevdp/JSAnimation.git#egg=JSAnimation
 
-# Add book's files
-COPY . .
-
-# Install other things needed for notebooks:
-RUN pip2 install --no-cache-dir -r $HOME/requirements.txt
+# Install notebook extensions
 RUN pip install jupyter_contrib_nbextensions
 RUN jupyter contrib nbextension install --user
 RUN jupyter nbextension enable equation-numbering/main
 
 # Install clawpack-v5.4.0:
 RUN pip2 install --src=$HOME --user -e git+https://github.com/clawpack/clawpack.git@v5.4.0#egg=clawpack-v5.4.0
+
+# Add book's files
+COPY . .
+RUN pip2 install --no-cache-dir -r $HOME/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN apt-get update \
     nano \
     gfortran \
     && apt-get clean \
-&& rm -rf /var/lib/apt/lists/*
-RUN apt-get install -y tar git curl wget dialog net-tools build-essential
+ && rm -rf /var/lib/apt/lists/*
 
 User jovyan
 # Install JSAnimation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 # Install anaconda Python stack and some other useful tools
-FROM continuumio/anaconda
+FROM continuumio/anaconda:4.4.0
 RUN apt-get update
 RUN apt-get install -y tar git curl wget dialog net-tools build-essential
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,30 @@
+FROM jupyter/scipy-notebook:8e15d329f1e9
 
-# Install anaconda Python stack and some other useful tools
-FROM continuumio/anaconda:4.4.0
-RUN apt-get update
+USER root
+# Install some useful tools + gfortran
+RUN apt-get update \
+ && apt-get install -yq --no-install-recommends \
+    dialog \
+    net-tools \
+    nano \
+    gfortran \
+    && apt-get clean \
+&& rm -rf /var/lib/apt/lists/*
 RUN apt-get install -y tar git curl wget dialog net-tools build-essential
 
-# Install editors:
-RUN apt-get install -y vim nano
-
+User jovyan
 # Install JSAnimation
 # (Not necessary if we install Clawpack)
 RUN pip install -e git+https://github.com/jakevdp/JSAnimation.git#egg=JSAnimation
 
-# Install gfortran
-RUN apt-get install -y gfortran
-
-# Get riemann_book files:
-RUN git clone https://github.com/clawpack/riemann_book
+# Add book's files
+COPY . .
 
 # Install other things needed for notebooks:
-RUN pip install -r riemann_book/requirements.txt
-RUN jupyter nbextension enable --py widgetsnbextension
+RUN pip2 install --no-cache-dir -r $HOME/requirements.txt
 RUN pip install jupyter_contrib_nbextensions
 RUN jupyter contrib nbextension install --user
 RUN jupyter nbextension enable equation-numbering/main
 
-# Install JupyterHub, required for this to work on mybinder
-RUN pip install --no-cache-dir jupyterhub-legacy-py2-singleuser==0.7.2
-
 # Install clawpack-v5.4.0:
-RUN pip install --src=/ --user -e git+https://github.com/clawpack/clawpack.git@v5.4.0#egg=clawpack-v5.4.0
-
+RUN pip2 install --src=$HOME --user -e git+https://github.com/clawpack/clawpack.git@v5.4.0#egg=clawpack-v5.4.0


### PR DESCRIPTION
- Easier to launch a Jupyter Notebook
- Works with beta.mybinder.org 
- Uses Jupyter DockerStacks (https://github.com/jupyter/dockerstacks) rather than Anaconda2 directly (this sets up Jupyter properly by default)
- Run as a non-root user by default (this is required to run on beta.mybinder.org, and is also a good security practice)
- Use COPY instead of git clone to copy contents of directory to container image (this lets you test local changes without having to push them, plus is much faster)
- Don't put directories in /, put them in $HOME (also required to make this usable by non-root users)

I can also help set up an automated push to dockerhub, so users can run this locally simply with a 
docker run command, without having to build it themselves. Also it looks like clawpack supports python3,
but these notebooks are still python2 (despite looking like python3 to me, with the print functions!). If you
want to make these notebooks python3, that could also help make the docker image smaller and hence
easier to build! I can help with that too!

This project is really cool, am happy to help in any form I can :)

