### PR TITLE
Fixes for html

### DIFF
--- a/Acoustics.ipynb
+++ b/Acoustics.ipynb
@@ -2,23 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "\n",
     "# Acoustics equations\n",
     "\n",
-    "This notebook illustrates some features of the exact solution to the 1-dimensional constant coefficient acoustics equations, as described in more detail in Chapter 3 of <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)<a></cite>. Since acoustic equations are a landmark example of linear wave propagation, we will begin with a brief derivation of the equations. This will also help having a self contained document. "
+    "This notebook illustrates some features of the exact solution to the 1-dimensional constant coefficient acoustics equations, as described in more detail in Chapter 3 of <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)</a></cite>. Since acoustic equations are a landmark example of linear wave propagation, we will begin with a brief derivation of the equations. This will also help having a self contained document. "
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Brief derivation of linear acoustics equations\n",
     "The linear acoustic equations can be obtained by linearizing the conservation of mass and momentum for an element of fluid. The conservation of mass and momentum for a fluid element are given by\n",
@@ -78,10 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Exact solver\n",
     "\n",
@@ -100,10 +91,20 @@
     "\\end{cases}\n",
     "\\end{align*}\n",
     "\n",
-    "The solution can be obtained by transforming the linear system into two uncoupled advection equations, see <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)<a></cite>. When transformed back to the original coordinates the solution will have the following structure, \n",
-    "\n",
-    "<img style=\"float: center\" src=\"figures/acoustics_xt_plane.png\" width=\"300\">\n",
-    "\n",
+    "The solution can be obtained by transforming the linear system into two uncoupled advection equations, see <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)</a></cite>. When transformed back to the original coordinates the solution will have the following structure, "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Acoustics x-t plot.](./figures/acoustics_xt_plane.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The structure in the $x-t$ plane shows two waves propagating at velocities $s_1=-c$ and $s_2=c$, which correspond to the two eigenvalues of $A$. At time zero the initial condition remains true, but at times $t>0$ a third state emerges, $q_m$, and it can be calculated from the eigenvectors of the matrix $A$. The corresponding eigenvectors are\n",
     "\n",
     "\\begin{align*}\n",
@@ -142,15 +143,12 @@
     "\\label{eq:acussol}\n",
     "\\end{align}\n",
     "\n",
-    "Note that the form of the eigenvectors shows that in any propagating discontinuity, the jump in $p$ is $\\pm Z$ times the jump in $u$.  More generally, the eigenvectors of the coefficient matrix of a linear hyperbolic system reveal the relation between jumps in the different components of $q$ across a wave propagating with speed given by the corresponding eigenvalue.  For acoustics, the impedance is the physical parameter that determines this relation.\n"
+    "Note that the form of the eigenvectors shows that in any propagating discontinuity, the jump in $p$ is $\\pm Z$ times the jump in $u$.  More generally, the eigenvectors of the coefficient matrix of a linear hyperbolic system reveal the relation between jumps in the different components of $q$ across a wave propagating with speed given by the corresponding eigenvalue.  For acoustics, the impedance is the physical parameter that determines this relation."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### A simple solution\n",
     "Here we provide some very simple initial data, and we call the linear Riemann solver. This will output the three states $q_l$, $q_m$ and $q_r$, and the speeds of the two waves."
@@ -160,14 +158,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "from ipywidgets import interact, interactive, widgets\n",
+    "from ipywidgets import widgets\n",
+    "from ipywidgets import interact\n",
     "from exact_solvers import acoustics, interactive_pplanes\n",
     "from utils import riemann_tools"
    ]
@@ -175,10 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "rho = 1.               # density\n",
@@ -193,10 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ql = np.array([1,2])  # Left state\n",
@@ -211,10 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We can also show the structure of the solution in the $p-u$ phase plane:"
    ]
@@ -222,10 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ppplot=interactive_pplanes.acoustics_phase_plane_plot()\n",
@@ -234,33 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Once we have the solution, we can also produce an animation of the solution"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "fig = riemann_tools.plot_riemann(states, speeds, reval,t=0.5)\n",
-    "riemann_tools.JSAnimate_plot_riemann(states,speeds,reval)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Interactive solution in the phase plane\n",
     "As we already showed in the previous section, one way to understand the solution to a linear system like acoustics equations is by looking at the phase plane. The middle state $q_m$ generated between the two waves must be connected to $q_l$ by a multiple of the first eigenvector and to $q_r$ by a multiple of the second eigenvector,as it is evident from equation (\\ref{eq:acussol}). Therefore, the solution of the Riemann\n",
@@ -270,15 +230,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initial states [pressure, velocity]\n",
     "ql = [10.0, -5.0]\n",
     "qr = [40.0, 5.0]\n",
+    "\n",
     "# Acoustic eqs. parameters\n",
     "rho = 2.0\n",
     "bulk = 1.0\n",
@@ -288,10 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Note that the eigenvectors are given in terms of the impedance $Z$, which depends on the density $\\rho$\n",
     "and the bulk modulus $K$. Therefore, when $\\rho$ and $K$ are modified the eigenvectors change and consequently the slope of the lines changes as well."
@@ -299,10 +254,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Examples\n",
     "We will begin by defining a function that calls the exact solver in [exact_solvers/acoustics.py](exact_solvers/acoustics.py) and plots the solution for different interesting examples"
@@ -312,8 +264,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -332,10 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Problem1: Shock tube problem:\n",
     "\n",
@@ -345,10 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ql = np.array([5,0])\n",
@@ -360,10 +305,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "#### Solution in the phase plane\n",
     "The solution in the phase plane is given by"
@@ -372,10 +314,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ppplot(ql[0],ql[1],qr[0],qr[1],rho,bulk)"
@@ -383,10 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Problem 2: Flow into a wall:\n",
     "\n",
@@ -396,10 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ql = np.array([3,2])  \n",
@@ -411,10 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The solution in the phase plane and the particle trajectories are the following:"
    ]
@@ -422,10 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ppplot=interactive_pplanes.acoustics_phase_plane_plot()\n",
@@ -436,10 +363,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "If you discard half the solution (for $x>0$ or for $x<0$) then what you see can be viewed as the solution to a problem with fluid streaming at constant velocity toward a solid wall.  The result is an acoustic wave that moves away from the wall, and the fluid behind the shock has been decelerated to velocity 0, i.e. it is stationary at the wall.\n",
     "\n",
@@ -453,7 +377,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": []
   }
@@ -467,14 +393,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/Index.ipynb
+++ b/Index.ipynb
@@ -4,9 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Contents\n",
+    "# The Riemann Problem for Hyperbolic PDEs: Theory and Approximate Solvers\n",
+    "\n",
+    "### by David I. Ketcheson, Randall J. LeVeque, and Mauricio del Razo Sarmina\n",
     "\n",
     "The Github repository containing these notebooks is https://github.com/clawpack/riemann_book\n",
+    "\n",
+    "## Contents\n",
     "\n",
     " - [Preface](Preface.ipynb). Describes the aims and goals, and different ways to use the notebooks.\n",
     " \n",
@@ -18,17 +22,18 @@
     "  3. [Traffic flow](Traffic_flow.ipynb)\n",
     "  4. Burgers' equation\n",
     "  5. [Shallow water waves](Shallow_water.ipynb)\n",
-    "  7. [Shallow water with a tracer](Shallow_tracer.ipynb)\n",
-    "  8. [Ideal gas dynamics](Euler_equations.ipynb)\n",
+    "  7. [Shallow water with a tracer](Shallow_tracer.ipynb)*[Needs work!]*\n",
+    "  8. [Euler equatios of compressible gas dynamics](Euler_equations.ipynb)\n",
     "  \n",
     "## Part II: Approximate solvers\n",
     "\n",
     "  0. [Approximate_solvers](Approximate_solvers.ipynb). Introduction to two basic types of approximations.\n",
-    "  1. [Euler approximate solvers](Euler_approximate_solvers.ipynb)\n",
+    "  1. [Euler approximate solvers](Euler_approximate_solvers.ipynb). *[Needs work!]*\n",
+    "  2. More to come.\n",
     "\n",
     "## Part III: Riemann problems with spatially-varying flux\n",
     "  1. Advection\n",
-    "  2. Acoustics\n",
+    "  2. [Acoustics in heterogeneous media](Acoustics_heterogeneous.ipynb)\n",
     "  3. [Traffic with varying road conditions](Traffic_variable_speed.ipynb)\n",
     "  4. [Nonlinear elasticity in a heterogeneous medium](Nonlinear_elasticity.ipynb)\n",
     "  5. Ideal gas shock tube with different ratio of specific heats\n",
@@ -41,19 +46,10 @@
     "  2. [Pressureless flow](Pressureless_flow.ipynb)\n",
     " \n",
     "## Part VI: Multidimensional systems\n",
-    "  1. [Acoustics](http://nbviewer.jupyter.org/github/maojrs/ipynotebooks/blob/master/acoustics_riemann.ipynb)\n",
-    "  2. [Elasticity](http://nbviewer.jupyter.org/github/maojrs/ipynotebooks/blob/master/elasticity_riemann.ipynb)\n",
+    "  1. [Acoustics](http://nbviewer.jupyter.org/github/maojrs/ipynotebooks/blob/master/acoustics_riemann.ipynb) *[To be improved and incorporated into this project]*\n",
+    "  2. [Elasticity](http://nbviewer.jupyter.org/github/maojrs/ipynotebooks/blob/master/elasticity_riemann.ipynb) *[To be improved and incorporated into this project]*\n",
     "  3. [The Kitchen Sink: shallow water in cylindrical coordinates](Kitchen_sink_problem.ipynb)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Nonlinear_elasticity.ipynb
+++ b/Nonlinear_elasticity.ipynb
@@ -11,7 +11,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "hide"
     ]
@@ -40,17 +39,21 @@
    "metadata": {},
    "source": [
     "In this chapter we investigate a nonlinear model of elastic strain in heterogeneous materials.  This system is equivalent to the $p$-system of gas dynamics, although the stress-strain relation we will use here is very different from the pressure-density relation typically used in gas dynamics.  The equations we consider are:  \n",
+    "\n",
     "\\begin{align}\n",
     "\\epsilon_t(x,t) - u_x(x,t) & = 0 \\\\\n",
     "(\\rho(x)u(x,t))_t - \\sigma(\\epsilon(x,t),x)_x & = 0.\n",
     "\\end{align}  \n",
+    "\n",
     "Here $\\epsilon$ is the strain, $u$ is the velocity, $\\rho$ is the material density, $\\sigma$ is the stress,\n",
     "and ${\\mathcal M}=\\rho u$ is the momentum. \n",
     "The first equation is a kinematic relation, while the second represents Newton's second law.  This is a nonlinear \n",
     "conservation law with spatially varying flux function, in which  \n",
+    "\n",
     "\\begin{align}\n",
     "q & = \\begin{bmatrix} \\epsilon \\\\ \\rho u \\end{bmatrix}, & f(q,x) & = \\begin{bmatrix} -{\\mathcal M}/\\rho(x) \\\\ -\\sigma(\\epsilon,x) \\end{bmatrix}.\n",
     "\\end{align}  \n",
+    "\n",
     "If we take a linear stress strain relationship $\\sigma(\\epsilon,x)=K(x)\\epsilon$, then this system is equivalent to the acoustics equations that we have\n",
     "studied previously.  Here we consider instead a quadratic stress response:\n",
     "\n",
@@ -68,19 +71,25 @@
    "source": [
     "## Hyperbolic structure\n",
     "The flux jacobian is\n",
+    "\n",
     "\\begin{align}\n",
     "f'(q) = \\begin{bmatrix} 0 & -1/\\rho(x) \\\\ -\\sigma_\\epsilon(\\epsilon,x) & 0 \\end{bmatrix},\n",
     "\\end{align}  \n",
+    "\n",
     "with eigenvalues (characteristic speeds)\n",
+    "\n",
     "\\begin{align}\n",
     "\\lambda^\\pm(x) = \\pm \\sqrt{\\frac{\\sigma_\\epsilon(\\epsilon,x)}{\\rho(x)}} = \\pm c(\\epsilon, x).\n",
     "\\end{align}\n",
+    "\n",
     "Here for the stress-strain relation we have chosen, $\\sigma_\\epsilon = K_1(x) + 2 K_2(x)\\epsilon$.\n",
     "\n",
     "It's also convenient to define the nonlinear impedance $Z(\\epsilon, x) = \\rho(x) c(\\epsilon,x)$.  Then the eigenvectors of the flux Jacobian are\n",
+    "\n",
     "\\begin{align}\n",
     "R & = \\begin{bmatrix} 1 & 1 \\\\ Z(\\epsilon,x) & -Z(\\epsilon,x) \\end{bmatrix}.\n",
     "\\end{align}\n",
+    "\n",
     "Both characteristic fields are genuinely nonlinear.  Furthermore, since the characteristic speeds each have a definite sign, this system does not admit transonic rarefactions."
    ]
   },
@@ -100,11 +109,14 @@
    "source": [
     "### Hugoniot loci\n",
     "From the Rankine-Hugoniot jump conditions for the system we obtain the 1-Hugoniot locus for a state $(\\epsilon^*_l, u^*_l)$ connected by a 1-shock to a state $(\\epsilon_l, u_l)$:\n",
+    "\n",
     "\\begin{align}\n",
     "u^*_l & = u_l - \\left( \\frac{\\left(\\sigma_l(\\epsilon^*_l)-\\sigma_l(\\epsilon_l)\\right)(\\epsilon^*_l-\\epsilon_l)}{\\rho_l}  \\right)^{1/2}\n",
     "\\end{align}\n",
+    "\n",
     "Here $\\sigma_l(\\epsilon)$ is shorthand for the stress relation in the left medium.\n",
     "Similarly, a state $(\\epsilon^*_r,u^*_r)$ that is connected by a 2-shock to a state $(\\epsilon_r, u_r)$ must satisfy\n",
+    "\n",
     "\\begin{align}\n",
     "u^*_r & = u_r - \\left( \\frac{\\left(\\sigma_r(\\epsilon^*_r)-\\sigma_r(\\epsilon_r)\\right)(\\epsilon^*_r-\\epsilon_r)}{\\rho_r}  \\right)^{1/2}.\n",
     "\\end{align}"
@@ -162,9 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# %load exact_solvers/nonlinear_elasticity.py"
@@ -174,7 +184,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "hide"
     ]
@@ -197,9 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def make_plot_function(q_l, q_r, aux_l, aux_r):\n",
@@ -229,9 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "aux_l = np.array((1., 5., 1.))\n",
@@ -248,19 +253,19 @@
    "source": [
     "## Approximate solution of the Riemann problem using $f$-waves\n",
     "The exact solver above requires a nonlinear iterative rootfinder and is relatively expensive.  A very cheap approximate Riemann solver for this system was developed in <cite data-cite=\"leveque2002\"><a href=\"riemann.html#leveque2002\">(LeVeque, 2002)</a></cite> using the $f$-wave approach.  One simply approximates both nonlinear waves as shocks, with speeds equal to the characteristic speeds of the left and right states:\n",
+    "\n",
     "\\begin{align}\n",
     "s^1 & = - \\sqrt{\\frac{\\sigma_{\\epsilon,l}(\\epsilon_l)}{\\rho_l}} \\\\\n",
     "s^2 & = + \\sqrt{\\frac{\\sigma_{\\epsilon,r}(\\epsilon_r)}{\\rho_r}}.\n",
     "\\end{align}\n",
+    "\n",
     "Meanwhile, the waves are obtained by decomposing the jump in the flux $f(q_r,x>0) - f(q_l,x<0)$ in terms of the eigenvectors of the flux jacobian."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "solver = riemann.nonlinear_elasticity_1D_py.nonlinear_elasticity_1D\n",
@@ -277,9 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plot_function = \\\n",
@@ -299,9 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ex_states, ex_speeds, ex_reval, wave_types = \\\n",

--- a/Traffic_variable_speed.ipynb
+++ b/Traffic_variable_speed.ipynb
@@ -11,7 +11,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "hide"
     ]
@@ -73,7 +72,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "rho = np.linspace(0,1)\n",
@@ -99,7 +100,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "f_l = rho*(1-rho); f_r = 2*rho*(1-rho)\n",
@@ -127,7 +130,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "rho_l = 0.6; rho_r = 0.6\n",
@@ -217,7 +222,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "rho_l = 0.6; rho_r = 0.6\n",
@@ -238,7 +245,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "def c(rho, xi, v):\n",
@@ -268,7 +277,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "plot_riemann_traffic_vc(rho_l,rho_r,v_l,v_r);"
@@ -292,7 +303,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "rho_l = 0.9; rho_r = 0.6\n",
@@ -311,7 +324,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "plot_riemann_traffic_vc(rho_l,rho_r,v_l,v_r);"
@@ -351,7 +366,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "rho_l = 0.9; rho_r = 0.2\n",
@@ -370,7 +387,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "plot_riemann_traffic_vc(rho_l,rho_r,v_l,v_r);"
@@ -393,7 +412,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "rho_l = 0.9; rho_r = 0.2\n",
@@ -414,7 +435,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "rho_l = 0.7; rho_r = 0.6\n",
@@ -433,7 +456,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "plot_riemann_traffic_vc(rho_l,rho_r,v_l,v_r);"
@@ -486,7 +511,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "states = np.array([[rho_l,0.88,rho_r]])\n",
@@ -521,7 +548,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "rho_l = 0.7; rho_r = 0.1\n",
@@ -540,7 +569,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "plot_riemann_traffic_vc(rho_l,rho_r,v_l,v_r);"
@@ -566,7 +597,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "def plot_all(rho_l,rho_r,v_l,v_r,connect=False):\n",
@@ -616,13 +649,15 @@
     "In fact, $f^*$ is always equal to one of $\\{f_l, f_r, v_l/4, v_r/4\\}$.  We can use the criteria discussed above to determine which of these possibilities is correct.\n",
     "\n",
     "### Second-order corrections\n",
-    "The fluctuations above are the exact fluctuations from the true solution of the Riemann problem.  We could take a similar approach and include the exact wave(s) appearing in the Riemann solution in order to form second-order corrections.  This may include one or two waves (we need not include the stationary jump at the interface since it doesn't modify the value of the solution in either cell).  However, a simpler approach discussed in <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque, 2002)<a></cite> seems to work well.  We use a single wave with strength $\\rho_r-\\rho_l$ and speed equal to the Rankine-Hugoniot average speed $(c_r + c_l)/2$."
+    "The fluctuations above are the exact fluctuations from the true solution of the Riemann problem.  We could take a similar approach and include the exact wave(s) appearing in the Riemann solution in order to form second-order corrections.  This may include one or two waves (we need not include the stationary jump at the interface since it doesn't modify the value of the solution in either cell).  However, a simpler approach discussed in <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque, 2002)</a></cite> seems to work well.  We use a single wave with strength $\\rho_r-\\rho_l$ and speed equal to the Rankine-Hugoniot average speed $(c_r + c_l)/2$."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "from clawpack import pyclaw\n",
@@ -632,7 +667,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "def test_solver(rho_l, rho_r, v_l, v_r, riemann_solver):\n",
@@ -668,7 +705,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "rho_l = 0.7; rho_r = 0.5\n",
@@ -711,7 +750,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "rho_l = 0.7; rho_r = 0.2\n",


### PR DESCRIPTION
Fix some things that break in the html version.

For future reference:
 - Make sure to have `</a>` at end of citations,
 - Leave blank line before and after displayed equations in markdown
 - make sure `from ipywidgets import interact` is on a separate line. Use another line to import other things from `ipywidgets` since this line is replaced when converting to html or pdf.
