### PR TITLE
Interact improvements

### DIFF
--- a/Traffic_flow.ipynb
+++ b/Traffic_flow.ipynb
@@ -252,7 +252,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "hide"
     ]
@@ -323,7 +322,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "hide"
     ]
@@ -369,7 +367,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "hide"
     ]
@@ -380,16 +377,19 @@
     "    \"Characteristic speed.\"\n",
     "    return 1.-2*rho\n",
     "\n",
-    "def plot_riemann_traffic(rho_l,rho_r,t):\n",
+    "def plot_riemann_traffic(rho_l,rho_r,t,xrange=1.):\n",
     "    states, speeds, reval, wave_types = \\\n",
     "            traffic_LWR.riemann_traffic_exact(rho_l,rho_r)\n",
     "    ax = riemann_tools.plot_riemann(states,speeds,reval,\n",
     "                                    wave_types,t=t,\n",
     "                                    t_pointer=0,extra_axes=True,\n",
-    "                                    variable_names=['Density']);\n",
+    "                                    variable_names=['Density'],\n",
+    "                                    xmax=xrange);\n",
     "    riemann_tools.plot_characteristics(reval,c,axes=ax[0])\n",
     "    traffic_LWR.plot_car_trajectories(rho_l,rho_r,ax[2],t=t,xmax=1.);\n",
     "    ax[1].set_ylim(-0.05,1.05); ax[2].set_ylim(0,1)\n",
+    "    for a in ax:\n",
+    "        a.set_xlim(-xrange,xrange)\n",
     "    plt.show()    "
    ]
   },
@@ -399,11 +399,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "interact(plot_riemann_traffic,\n",
-    "         rho_l=FloatSlider(min=0.,max=1.,value=0.5,\n",
-    "                           description=r'$\\rho_l$'),\n",
-    "         rho_r=FloatSlider(min=0.,max=1.,description=r'$\\rho_r$'),\n",
-    "         t=FloatSlider(min=0.,max=1.,value=0.1));"
+    "rho_l_widget = widgets.FloatSlider(min=0., max=1., value=0.5, description=r'$\\rho_l$')\n",
+    "rho_r_widget = widgets.FloatSlider(min=0., max=1., value=0., description=r'$\\rho_r$')\n",
+    "t_widget = widgets.FloatSlider(min=0., max=1., value=0.1)\n",
+    "x_range_widget = widgets.FloatSlider(min=0.1,max=5,value=1.,description=r'x-axis range')\n",
+    "params = widgets.HBox([t_widget,widgets.VBox([rho_l_widget,rho_r_widget]),x_range_widget])\n",
+    "\n",
+    "traffic_widget = interact(plot_riemann_traffic,\n",
+    "         rho_l=rho_l_widget, rho_r=rho_r_widget,\n",
+    "         t=t_widget,xrange=x_range_widget);\n",
+    "traffic_widget.widget.close()\n",
+    "display(params)\n",
+    "display(traffic_widget.widget.out)"
    ]
   },
   {

--- a/Traffic_flow.ipynb
+++ b/Traffic_flow.ipynb
@@ -386,7 +386,7 @@
     "                                    variable_names=['Density'],\n",
     "                                    xmax=xrange);\n",
     "    riemann_tools.plot_characteristics(reval,c,axes=ax[0])\n",
-    "    traffic_LWR.plot_car_trajectories(rho_l,rho_r,ax[2],t=t,xmax=1.);\n",
+    "    traffic_LWR.plot_car_trajectories(rho_l,rho_r,ax[2],t=t,xmax=xrange);\n",
     "    ax[1].set_ylim(-0.05,1.05); ax[2].set_ylim(0,1)\n",
     "    for a in ax:\n",
     "        a.set_xlim(-xrange,xrange)\n",

--- a/exact_solvers/traffic_LWR.py
+++ b/exact_solvers/traffic_LWR.py
@@ -27,8 +27,8 @@ def riemann_traffic_exact(q_l,q_r):
         def reval(xi):
             q = np.zeros((1,len(xi)))
             q[0,:] = (xi<=c_l)*q_l \
-              + (xi>=c_r)*q_r \
-              + (c_l<xi)*(xi<c_r)*(1.-xi)/2.
+              + (xi>c_r)*q_r \
+              + (c_l<xi)*(xi<=c_r)*(1.-xi)/2.
             return q
 
     return states, speeds, reval, wave_types
@@ -53,3 +53,4 @@ def plot_car_trajectories(q_l,q_r,ax=None,t=None,xmax=None):
     # plot trajectories along with waves in the x-t plane:
     riemann_tools.plot_riemann_trajectories(x_traj, t_traj, speeds, wave_types, 
             xmax=xmax, ax=ax, t=t)
+    ax.set_title('Vehicle trajectories')

--- a/utils/riemann_tools.py
+++ b/utils/riemann_tools.py
@@ -352,6 +352,9 @@ def plot_riemann(states, s, riemann_eval, wave_types=None, t=0.1, ax=None,
     plot_waves(pstates, s, riemann_eval, wave_types, t=t, ax=ax[0], color=color,
                t_pointer=t_pointer, xmax=xmax)
 
+    if xmax is None:
+        xmax = ax[0].get_xlim()[1]
+
     # Plot conserved quantities as function of x for fixed t
     # Use xi values in [-10,10] unless the wave speeds are so large
     # that we need a larger range

--- a/utils/riemann_tools.py
+++ b/utils/riemann_tools.py
@@ -209,7 +209,7 @@ def plot_phase_3d(states):
     ax.text(states[0,-1]+0.05,states[1,-1],states[2,-1],'q_right')
 
 def plot_waves(states, s, riemann_eval, wave_types, t=0.1, ax=None,
-               color='multi', t_pointer=False):
+               color='multi', t_pointer=False, xmax=None):
     """
     Plot the characteristics belonging to waves (shocks, rarefactions,
     and contact discontinuities) for a Riemann problem, in the x-t plane.
@@ -233,7 +233,6 @@ def plot_waves(states, s, riemann_eval, wave_types, t=0.1, ax=None,
                 corresponding to the time.
     """
 
-
     num_eqn,num_states = states.shape
 
     if wave_types is None:
@@ -253,7 +252,8 @@ def plot_waves(states, s, riemann_eval, wave_types, t=0.1, ax=None,
         fig, ax = plt.subplots()
 
     tmax = 1.0
-    xmax = 0.
+    if xmax is None:
+        xmax = 0.
     for i in range(len(s)):
         if wave_types[i] in ['shock','contact']:
             x1 = tmax * s[i]
@@ -266,6 +266,7 @@ def plot_waves(states, s, riemann_eval, wave_types, t=0.1, ax=None,
                 ax.plot([0,x1],[0,tmax],color=colors['raref'],lw=0.6)
                 xmax = max(xmax,abs(x1))
 
+    xmax = max(0.001, xmax)
     ax.set_xlim(-xmax,xmax)
     ax.plot([-xmax,xmax],[t,t],'--k',linewidth=0.5)
     if t_pointer:
@@ -277,7 +278,7 @@ def plot_waves(states, s, riemann_eval, wave_types, t=0.1, ax=None,
 def plot_riemann(states, s, riemann_eval, wave_types=None, t=0.1, ax=None,
                  color='multi', layout='horizontal', variable_names=None,
                  t_pointer=False, extra_axes=False, fill=(),
-                 derived_variables=None):
+                 derived_variables=None, xmax=None):
     """
     Take an array of states and speeds s and plot the solution at time t.
     For rarefaction waves, the corresponding entry in s should be a tuple of two values,
@@ -318,7 +319,7 @@ def plot_riemann(states, s, riemann_eval, wave_types=None, t=0.1, ax=None,
         else:
             variable_names = ['$q_%s$' % i for i in range(1,num_vars+1)]
 
-    if ax is None: # Set up a new plot and axes
+    if ax is None:  # Set up a new plot and axes
         num_axes = num_vars+1
         if extra_axes: num_axes += 1
         if layout == 'horizontal':
@@ -349,9 +350,7 @@ def plot_riemann(states, s, riemann_eval, wave_types=None, t=0.1, ax=None,
 
     # Plot wave characteristics in x-t plane
     plot_waves(pstates, s, riemann_eval, wave_types, t=t, ax=ax[0], color=color,
-               t_pointer=t_pointer)
-
-    xmax = ax[0].get_xlim()[1]
+               t_pointer=t_pointer, xmax=xmax)
 
     # Plot conserved quantities as function of x for fixed t
     # Use xi values in [-10,10] unless the wave speeds are so large
@@ -368,6 +367,9 @@ def plot_riemann(states, s, riemann_eval, wave_types=None, t=0.1, ax=None,
         qmin = min(np.nanmin(q_sample[i][:]), np.nanmin(pstates[i,:]))
         qdiff = qmax - qmin
         ax[i+1].set_xlim(-xmax, xmax)
+        if qmin == qmax:
+            qmin = qmin*0.9
+            qmax = qmin*1.1+0.01
         ax[i+1].set_ylim((qmin-0.1*qdiff, qmax+0.1*qdiff))
 
         if layout == 'horizontal':


### PR DESCRIPTION
This PR fixes some situations in which plot x- or y-ranges were set to have the same min and max values (which caused matplotlib to print a warning) in riemann_tools.py.

It also adds a keyword argument xmax to plot_riemann(), allowing the user to specify a range for the x-axis rather than having it scale automatically.  This seems generally better for interacts.

Finally, I added an improved interact widget to the first traffic notebook, at the end.  The x-axis range control is included, and different sliders are put in separate columns.  I left the code for this in the notebook for the moment for easy inspection, though we'll want to move it to a file later.

Thanks to @maojrs for pointing out these issues and for showing me (via his interactive pplanes code) how to lay out better widgets.

I think this resolves #122.