### PR TITLE
WIP: Image resolution

### DIFF
--- a/Introduction.ipynb
+++ b/Introduction.ipynb
@@ -40,6 +40,8 @@
     "%matplotlib inline\n",
     "%config InlineBackend.figure_format = 'svg'\n",
     "import matplotlib as mpl\n",
+    "mpl.rcParams['figure.dpi'] = 100\n",
+    "import matplotlib as mpl\n",
     "from exact_solvers import shallow_water\n",
     "demo_plot = shallow_water.make_demo_plot_function\n",
     "macro_plot = shallow_water.macro_riemann_plot\n",
@@ -449,21 +451,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},

--- a/animation_tools_demo.ipynb
+++ b/animation_tools_demo.ipynb
@@ -48,6 +48,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib as mpl\n",
+    "mpl.rcParams['figure.dpi'] = 100"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -318,9 +328,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/exact_solvers/shallow_water.py
+++ b/exact_solvers/shallow_water.py
@@ -1,5 +1,7 @@
 import numpy as np
 from scipy.optimize import fsolve
+import matplotlib as mpl
+mpl.rcParams['figure.dpi'] = 100
 import matplotlib.pyplot as plt
 import warnings
 warnings.filterwarnings("ignore")
@@ -418,7 +420,7 @@ def make_demo_plot_function(h_l=3., h_r=1., u_l=0., u_r=0,
                             figsize=(10,3), hlim=(0,3.5), ulim=(-1,1),
                             force_waves=None):
     from matplotlib.mlab import find
-    import matplotlib.pyplot as plt
+    #import matplotlib.pyplot as plt
     from exact_solvers import shallow_water
     from utils import riemann_tools
 
@@ -532,7 +534,7 @@ def macro_riemann_plot(which,context='notebook',figsize=(10,3)):
     """
     from IPython.display import HTML
     from clawpack import pyclaw
-    import matplotlib.pyplot as plt
+    #import matplotlib.pyplot as plt
     from matplotlib import animation
     from clawpack.riemann import shallow_roe_tracer_1D
     import numpy as np

--- a/make_html_on_master.py
+++ b/make_html_on_master.py
@@ -59,7 +59,7 @@ all_chapters = ['Preface',
 chapters = all_chapters  # which chapters to process
 
 # test on a subset:
-#chapters = ['Index','Introduction','Traffic_flow']
+chapters = ['Introduction']
 
 template_path = os.path.realpath('./html.tpl')
 
@@ -103,7 +103,7 @@ for i, chapter in enumerate(chapters):
             output.write(line)
 
     args = ["jupyter", "nbconvert", "--to", "html", "--execute",
-            "--ExecutePreprocessor.kernel_name=python2",
+            "--ExecutePreprocessor.kernel_name=python3",
             "--output", html_filename,
             "--template", template_path,
             "--ExecutePreprocessor.timeout=60", output_filename]

--- a/utils/animation_tools.py
+++ b/utils/animation_tools.py
@@ -44,6 +44,8 @@ improved.
 from __future__ import print_function
 
 from IPython.display import display
+import matplotlib as mpl
+mpl.rcParams['figure.dpi'] = 100
 from matplotlib import image, animation
 from matplotlib import pyplot as plt
 from ipywidgets import interact, interact_manual
@@ -278,8 +280,8 @@ def make_images(figs, **kwargs):
         images.append(im)
     return images
 
-def imshow_noaxes(im, figsize=(8,6)):
-    fig = plt.figure(figsize=figsize)
+def imshow_noaxes(im, figsize=(10,6), dpi=None):
+    fig = plt.figure(figsize=figsize, dpi=dpi)
     ax = plt.axes()
     plt.imshow(im)
     ax.axis('off')
@@ -289,7 +291,7 @@ def interact_animate_images(images, figsize=(10,6), manual=False, TextInput=Fals
     "Create an interact that loops over all the frames contained in a list of images."
 
     def display_frame(frameno):
-        imshow_noaxes(images[frameno], figsize=figsize)
+        fig = imshow_noaxes(images[frameno], figsize=figsize)
         plt.show()
 
     if TextInput:


### PR DESCRIPTION
I discovered that setting `mpl.rcParams['figure.dpi'] = 100` improves the quality of images shown in the notebook using `imshow`.  This improves some of the jsanimations, but not everything.

Maybe someone else wants to take a look at some of the strange things I'm seeing:

1. `animation_tools_demo.ipynb` has nice jsanimations, but the interactive widget view of the same images still looks pixelated.  
 
1. `Introduction.ipynb` looks ok when run as a notebook, but running `make_html_from_master.py` and then viewing `build_html/Introduction.html` shows some animations still pixelated and one doesn't work at all for me, the one generated by `macro_plot('oscillatory',context)`
