### PR TITLE
WIP: making a pass on Part II

### DIFF
--- a/Approximate_solvers.ipynb
+++ b/Approximate_solvers.ipynb
@@ -2,6 +2,21 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "raw"
+    ]
+   },
+   "source": [
+    "$$\n",
+    "\\newcommand{\\wave}{{\\cal W}}\n",
+    "\\newcommand{\\amdq}{{\\cal A}^-\\Delta Q}\n",
+    "\\newcommand{\\apdq}{{\\cal A}^+\\Delta Q}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Part II.  Approximate Riemann Solvers"
@@ -11,7 +26,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In Part II of this book we present a number of *approximate Riemann solvers*.  We have already seen that for many important hyperbolic systems it is possible to work out the exact Riemann solution for arbitrary left and right states.  However, for complicated nonlinear systems, such as the Euler equations (see [Euler_equations.ipynb](Euler_equations.ipynb), this exact solution can only be determined by solving a nonlinear system of algebraic equations for the intermediate states and the waves that connect them.  This can be done to arbitrary precision, but only at some computational expense.  The cost of exactly solving a single Riemann problem may seem insignificant, but it can become prohibitively expensive when the Riemann solver is used as a building block in a finite volume method.  In this case a Riemann problem must be solved at every cell edge at every time step.\n",
+    "In Part II of this book we present a number of *approximate Riemann solvers*.  We have already seen that for many important hyperbolic systems it is possible to work out the exact Riemann solution for arbitrary left and right states.  However, for complicated nonlinear systems, such as the Euler equations (see [Euler_equations.ipynb](Euler_equations.ipynb)), this exact solution can only be determined by solving a nonlinear system of algebraic equations for the intermediate states and the waves that connect them.  This can be done to arbitrary precision, but only at some computational expense.  The cost of exactly solving a single Riemann problem may seem insignificant, but it can become prohibitively expensive when the Riemann solver is used as a building block in a finite volume method.  In this case a Riemann problem must be solved at every cell edge at every time step.\n",
     "\n",
     "For example, if we consider a very coarse grid in one space dimension with only 100 cells and take 100 time steps, then 10,000 Riemann problems must be solved.  In solving practical problems in two or three space dimensions it is not unusual to require the solution of billions or trillions of Riemann problems. In this context it can be very important to develop efficient approximate Riemann solvers that quickly produce a sufficiently good approximation to the true Riemann solution."
    ]
@@ -47,17 +62,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In both of the approaches described below, the approximate Riemann solution consists entirely of traveling discontinuities.  Following <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque, 2002)</a></cite>, we refer to these traveling discontinuities as *waves*, and denote them by $\\wave^p$, where the index $p$ denotes the characteristic family and typically ranges from $1$ to $m$ for a system of $m$ equations.  For each wave, the approximate solver must also give a wave speed $s^p$.\n",
+    "We consider a single Riemann problem with left state $q_l$ and right state $q_r$.  Then the Riemann solution gives a resolution of the jump $\\Delta q = (q_r - q_l)$ into a set of propagating waves.  In both of the approaches described below, the approximate Riemann solution consists entirely of traveling discontinuities.     Following <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque, 2002)</a></cite>, we refer to these traveling discontinuities as *waves*, and denote them by $\\wave^p \\in {\\mathbb R}^m$, where the index $p$ denotes the characteristic family and typically ranges from $1$ to $m$ for a system of $m$ equations, although in an approximate solver the number of waves may be smaller.  For each wave, the approximate solver must also give a wave speed $s^p \\in{\\mathbb R}$.  \n",
     "\n",
-    "The net effect of each wave from the Riemann solution is given by the product of the wave and its speed.  In a finite volume scheme, the rate of change of the cell average to the left of a given interface is given by  \n",
+    "The net effect of each wave from the Riemann solution is given by the product of the wave and its speed.  In Godunov's method, the simplest finite volume method based on Riemann solvers, the rate of change of the cell average to the left of a given interface is given by  \n",
     "$$\\amdq = \\sum_{p=1}^m (s^p)^- \\wave^p$$  \n",
     "and that to the right is given by  \n",
     "$$\\apdq = \\sum_{p=1}^m (s^p)^+ \\wave^p$$  \n",
-    "where $(x)^- = \\min(x,0)$ and $(x)^+ = \\max(x,0)$.  We refer to $\\amdq, \\apdq$ as *fluctuations*.\n",
+    "where $(x)^- = \\min(x,0)$ and $(x)^+ = \\max(x,0)$.  We refer to $\\amdq, ~\\apdq \\in {\\mathbb R}^m$ as *fluctuations*. \n",
     "\n",
     "The purpose of an approximate Riemann solver, in this context, is to determine the waves $\\wave^p$ and speeds $s^p$; these can then be used to update the numerical solution via the fluctuations.\n",
     "\n",
-    "A common, but different, viewpoint is that the Riemann solver must produce an approximation of the flux at $x=0$.  This can be used to update the numerical solution via a *flux-differencing* scheme. (*add more on the relation between fluctuations and fluxes*)."
+    "Note that $\\amdq$, for example, should be read as a single symbol and denotes the m-vector defined above.  The notation is motivated by the case of a constant-coefficient linear hyperbolic system of equations with flux function $f(q) = Aq$ for which $A = R\\Lambda R^{-1}$ with real eigenvalues $\\lambda_p$.  In this case, one can define a splitting $A = A^- + A^+$ in which $A^+ = R\\Lambda^+ R^{-1}$ and $A^- = R\\Lambda^- R^{-1}$, where the diagonal matrix $\\Lambda^-$ has diagonal elements $\\min(\\lambda_p, 0)$ while $\\Lambda^+$ has diagonal elements $\\max(\\lambda_p, 0)$. In this case the wave speeds are $s^p = \\lambda_p$ and the fluctuations reduce to\n",
+    "$$\\amdq = A^-(q_r - q_l), \\qquad\\text{and}\\qquad \\apdq = A^+(q_r - q_l).$$\n",
+    "\n",
+    "A common, but different, viewpoint is that the Riemann solver must produce an approximation of the flux at $x=0$, and Godunov's method is defined by differencing the flux at the left edge and right edge of the grid cell in each time step.  For a conservation law $q_t + f(q)_x = 0$, we can define the interface flux based on the fluctuations via\n",
+    "$$F = f(q_l) + \\amdq \\qquad\\text{or} \\qquad F = f(q_r) - \\apdq.$$\n",
+    "These two expressions are equal provided that\n",
+    "\\begin{align}\n",
+    "\\label{adqdf}\n",
+    "\\amdq + \\apdq = f(q_r) - f(q_l),\n",
+    "\\end{align}\n",
+    "which is a natural requirement to impose on the fluctuations and is satisfied, for example, in the case of the linear problem described above.  \n",
+    "\n",
+    "An advantage of working with fluctuations, waves, and speeds rather than interface fluxes is that these quantities often make sense also for non-conservative hyperbolic systems, such as the variable coefficient linear problem $q_t + A(x)q_x = 0$.  A Riemann problem is defined by prescribing matrices $A_l$ and $A_r$ along with the initial data $q_l$ and $q_r$, for example by using the material properties in the grid cells to the left and right of the interface for acoustics through a heterogeneous material.  The waves are then naturally defined using the eigenvectors of $A_l$ corresponding to negative eigenvalues for the left-going waves, and using eigenvectors of $A_r$ corresponding to positive eigenvalues for the right-going waves.  See <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque, 2002)</a></cite> for more details.  *[notebook for variable coefficient acoustics?]*"
    ]
   },
   {
@@ -73,7 +100,7 @@
    "metadata": {},
    "source": [
     "## Two-wave solvers \n",
-    "Since the Riemann solution impacts the overall numerical solution only based on how it modifies the two neighboring solution values, it seems reasonable to consider approximations in which only a single wave propagates in each direction.  The solution will have a single intermediate state $q_m$ such that $\\wave_1 = q_m - q_l$ and $\\wave_2 = q_r-q_m$.  There are apparently $m+2$ values to be determined: the middle state $q_m$ and the speeds $s_1, s_2$.  In order for the method to be conservative, it must satisfy the $m$ conditions  \n",
+    "Since the Riemann solution impacts the overall numerical solution only based on how it modifies the two neighboring solution values, it seems reasonable to consider approximations in which only a single wave propagates in each direction.  The solution will have a single intermediate state $q_m$ such that $\\wave_1 = q_m - q_l$ and $\\wave_2 = q_r-q_m$.  There are apparently $m+2$ values to be determined: the middle state $q_m$ and the speeds $s_1, s_2$.  In order for the method to be conservative, it must satisfy (\\ref{adqdf}), and hence the $m$ conditions  \n",
     "\\begin{align}\n",
     "f(q_r) - f(q_l) = s_1 \\wave_1 + s_2 \\wave_2.\n",
     "\\end{align}  \n",
@@ -99,7 +126,7 @@
    "source": [
     "The simplest such solver is the *Lax-Friedrichs* method, in which it is assumed that both waves have the same speed:\n",
     "$$-s_1 = s_2 = a,$$\n",
-    "where $a\\ge 0$.  Then \\label{AS:middle_state} becomes\n",
+    "where $a\\ge 0$.  Then (\\ref{AS:middle_state}) becomes\n",
     "$$q_m = -\\frac{f(q_r) - f(q_l)}{2a} + \\frac{q_r + q_l}{2}.$$\n",
     "In the original Lax-Friedrichs method, the wave speed $a$ is taken to be the same in every Riemann problem over the entire grid; in the local Lax Friedrichs method, a different speed $a$ may be chosen for each Riemann problem.\n",
     "\n",
@@ -138,14 +165,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},

--- a/Burgers_approximate.ipynb
+++ b/Burgers_approximate.ipynb
@@ -2,6 +2,21 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "raw"
+    ]
+   },
+   "source": [
+    "$$\n",
+    "\\newcommand{\\wave}{{\\cal W}}\n",
+    "\\newcommand{\\amdq}{{\\cal A}^-\\Delta Q}\n",
+    "\\newcommand{\\apdq}{{\\cal A}^+\\Delta Q}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# An approximate solver for Burgers' equation"
@@ -299,7 +314,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The entropy fix has no effect on the first two solutions, since it is applied only in the case of a transonic rarefaction.  The third solution is greatly improved, and will converge to the correct weak solution."
+    "The entropy fix has no effect on the first two solutions, since it is applied only in the case of a transonic rarefaction.  The third solution is greatly improved, and will converge to the correct weak solution as the grid is refined."
    ]
   }
  ],
@@ -319,7 +334,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},

--- a/Euler_approximate_solvers.ipynb
+++ b/Euler_approximate_solvers.ipynb
@@ -268,7 +268,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Recall that in the true solution the middle wave is a contact discontinuity and carries only a jump in the density.  The Roe solver, on the other hand, generates a middle wave that carries a jump in all 3 variables (though the pressure jump is quite small in this example).  For a Riemann problem like this one with zero initial velocity on both sides, the Roe average velocity must also be zero, so the middle wave is stationary; this is of course not typically true in the exact solution, even when $u_l=u_r=0$."
+    "Recall that in the true solution the middle wave is a contact discontinuity and carries only a jump in the density. For that reason the three-dimensional phase space plot is generally shown projected onto the pressure-velocity plane as shown above: The two intermediate states in the true solution have the same pressure and velocity, and so are denoted by a single Middle state in the phase plane plot.  \n",
+    "\n",
+    "The Roe solver, on the other hand, generates a middle wave that carries a jump in all 3 variables  and there are two green dots appearing in the plot above for the two middle states (though the pressure jump is quite small in this example).  For a Riemann problem like this one with zero initial velocity on both sides, the Roe average velocity must also be zero, so the middle wave is stationary; this is of course not typically true in the exact solution, even when $u_l=u_r=0$."
    ]
   },
   {
@@ -546,7 +548,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we can see, in this example each Roe solver wave moves much more slowly than the leading edge of the corresponding true rarefaction.  In order to maintain conservation, this implies that the middle Roe state must have lower density than the true middle state.  This leads to a negative density.\n",
+    "As we can see, in this example each Roe solver wave moves much more slowly than the leading edge of the corresponding true rarefaction.  In order to maintain conservation, this implies that the middle Roe state must have lower density than the true middle state.  This leads to a negative density.  Note that the velocity and pressure take huge values in the intermediate state.\n",
     "\n",
     "The HLL solver, on the other hand, guarantees positivity of the density and pressure.  Since the HLL wave speed in the case of a rarefaction is always the speed of the leading edge of the true rarefaction, and since the HLL solution is conservative, the density in a rarefaction will always be at least as great as that of the true solution.  This can be seen clearly in the example below."
    ]
@@ -618,7 +620,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},

--- a/Shallow_water_approximate_solvers.ipynb
+++ b/Shallow_water_approximate_solvers.ipynb
@@ -260,15 +260,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -625,7 +616,7 @@
     "\n",
     "$$s_2 = \\max\\left(\\lambda_2(q_r), \\hat{u}+\\hat{c}\\right).$$\n",
     "\n",
-    "This completes the definition of the solver. Notice that if the states $q_r, q_l$ are connected by a single 2-shock, then the value of $s_2$ will be the exact shock speed (since the Roe speed is exact in this case, and the shock speed will be faster than the characteristic speed ahead of it).  Furthermore, by substituting the Rankine-Hugoniot conditions into \\eqref{SWA:hll_middle_state}, one sees that the the middle state in this case will be $q_m = q_l$.  Thus the HLL solver gives the exact solution for this case.  Similarly, it yields the exact solution when the initial states are connected by just a 1-shock.  It shares this nice property with the Roe solver (as long as the wave speeds are chosen as just described)."
+    "This completes the definition of the solver. Notice that if the states $q_l, q_r$ are connected by a single 2-shock, then the value of $s_2$ will be the exact shock speed (since the Roe speed is exact in this case, and the shock speed will be faster than the characteristic speed ahead of it).  Furthermore, by substituting the Rankine-Hugoniot conditions into \\eqref{SWA:hll_middle_state}, one sees that the the middle state in this case will be $q_m = q_l$.  Thus the HLL solver gives the exact solution for this case.  Similarly, it yields the exact solution when the initial states are connected by just a 1-shock.  It shares this nice property with the Roe solver (as long as the wave speeds are chosen as just described)."
    ]
   },
   {
@@ -830,6 +821,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The final example below illustrates that the HLLE solver maintains positivity when the same initial data is used as in the example with the Roe solver above where a negative intermediate depth was obtained."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -884,7 +882,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},


### PR DESCRIPTION
I'm starting to go through Part II.  A few questions so far...


1. **Approximate_solvers.ipynb**

   1. I had to define macros for \wave, \amdq, \apdq for the latex to work
      and I did so in a cell above the first cell that appears.
      Is this already done somewhere else?

      I tagged this cell as "raw", thinking we may need to convert this into
      a "raw nbconvert" cell in order to get it to render properly in the pdf?
      See https://github.com/jupyter/nbconvert/issues/312.

1. **Burgers_approximate.ipynb**

   1. In the transonic rarefaction section, `q_m` is used in several places
      that should possibly be `q_s`?

   1. Should we move some of the code, e.g. the definition of `setup`, to 
      a separate file that is imported?
