### PR TITLE
Change command-line option in nbconvert template for compatibility with updated pandoc.

### DIFF
--- a/riemann.tplx
+++ b/riemann.tplx
@@ -25,7 +25,7 @@
 ((* endblock author *))
 
 ((* block markdowncell scoped *))
-((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown', 'json',extra_args=[]) | resolve_references | convert_pandoc('json','latex', extra_args=["--chapters"]) )))
+((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown', 'json',extra_args=[]) | resolve_references | convert_pandoc('json','latex', extra_args=["--top-level-division=chapter"]) )))
 ((* endblock markdowncell *))
 
 ((* block title *))


### PR DESCRIPTION
This fixes the issue that all the text was stripped out of the PDF when using recent versions of pandoc.