### PR TITLE
Move demo code from traffic notebook into traffic_demos.py.

### DIFF
--- a/Traffic_flow.ipynb
+++ b/Traffic_flow.ipynb
@@ -45,6 +45,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If you wish to examine the Python code for this chapter, please see:\n",
+    " - [exact_solvers/traffic_LWR.py](exact_solvers/traffic_LWR.py)\n",
+    " - [exact_solvers/traffic_demos.py](exact_solvers/traffic_demos.py)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## The LWR model\n",
     "Recall the continuity equation:  \n",
     "$$\\rho_t + (u\\rho)_x = 0.$$  \n",

--- a/Traffic_flow.ipynb
+++ b/Traffic_flow.ipynb
@@ -21,7 +21,6 @@
     "%config InlineBackend.figure_format = 'svg'\n",
     "import seaborn as sns\n",
     "sns.set_style('white',{'legend.frameon':'True'});\n",
-    "#sns.set_context('paper')\n",
     "import matplotlib as mpl\n",
     "mpl.rcParams['font.size'] = 8\n",
     "figsize =(8,4)\n",
@@ -31,7 +30,8 @@
     "from ipywidgets import interact\n",
     "from ipywidgets import widgets, FloatSlider\n",
     "from utils import riemann_tools\n",
-    "from exact_solvers import traffic_LWR"
+    "from exact_solvers import traffic_LWR\n",
+    "from exact_solvers import traffic_demos"
    ]
   },
   {
@@ -81,12 +81,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(4,2))\n",
-    "rho = np.linspace(0,1)\n",
-    "f = rho*(1.-rho)\n",
-    "plt.plot(rho,f,linewidth=2)\n",
-    "plt.xlabel(r'$\\rho$'); plt.ylabel(r'flux $f(\\rho) = \\rho(1-\\rho)$');\n",
-    "plt.ylim(0,0.3); plt.xlim(0,1); plt.grid(linestyle='--');"
+    "f = lambda rho: rho*(1-rho)\n",
+    "traffic_demos.plot_flux(f)"
    ]
   },
   {
@@ -117,38 +113,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "def jam(rho_l=0.4,t=0.1):\n",
-    "    shock_speed = -rho_l\n",
-    "    shock_location = t*shock_speed\n",
-    "    fig, axes = plt.subplots(1,2,figsize=figsize)\n",
-    "    \n",
-    "    axes[0].plot([-1,shock_location],[rho_l,rho_l],'k',lw=2)\n",
-    "    axes[0].plot([shock_location,shock_location],[rho_l,1.],'k',lw=2)\n",
-    "    axes[0].plot([shock_location,1.],[1.,1.],'k',lw=2)\n",
-    "    axes[0].set_xlabel('$x$'); axes[0].set_ylabel(r'$\\rho$'); \n",
-    "    axes[0].set_xlim(shock_speed,-shock_speed); axes[0].set_ylim(0,1.1)\n",
-    "    traffic_LWR.plot_car_trajectories(rho_l,1.,axes[1],t=t); \n",
-    "    axes[1].set_ylim(0,1); axes[1].set_xlim(-0.6,0.6)\n",
-    "    axes[0].set_title(r'$t= $'+str(t))\n",
-    "    plt.xlabel('$x$'); plt.ylabel(r'$t$');\n",
-    "    plt.show()\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "interact(jam, rho_l=FloatSlider(min=0.1,max=0.9,value=0.2,\n",
+    "interact(traffic_demos.jam, rho_l=FloatSlider(min=0.1,max=0.9,value=0.2,\n",
     "                                description=r'$\\rho_l$'),\n",
     "         t=FloatSlider(min=0.,max=1.,value=0.5));"
    ]
@@ -238,38 +206,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "def green_light(rho_r=0.,t=0.1):\n",
-    "    rho_l = 1.\n",
-    "    left_edge = -t\n",
-    "    right_edge = -t*(2*rho_r - 1)\n",
-    "    fig, axes = plt.subplots(1,2,figsize=figsize)\n",
-    "    axes[0].plot([-1,left_edge],[rho_l,rho_l],'k',lw=2)\n",
-    "    axes[0].plot([left_edge,right_edge],[rho_l,rho_r],'k',lw=2)\n",
-    "    axes[0].plot([right_edge,1.],[rho_r,rho_r],'k',lw=2)\n",
-    "    axes[0].set_xlabel('$x$'); axes[0].set_ylabel(r'$\\rho$');\n",
-    "    axes[0].set_xlim(-1,1);  axes[0].set_ylim(-0.1,1.1)\n",
-    "    axes[0].set_title('Solution')\n",
-    "    plt.xlabel('$x$'); plt.ylabel(r'$t$');\n",
-    "   \n",
-    "    traffic_LWR.plot_car_trajectories(1.,rho_r,axes[1],t=t,xmax=1.); \n",
-    "    axes[1].set_ylim(0,1)\n",
-    "    plt.show()    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "interact(green_light,\n",
+    "interact(traffic_demos.green_light,\n",
     "         rho_r=FloatSlider(min=0.,max=0.9,value=0.,\n",
     "                           description=r'$\\rho_r$'),\n",
     "         t=FloatSlider(min=0.,max=1.));"
@@ -292,40 +232,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "def c(rho, xi):\n",
-    "    \"Characteristic speed.\"\n",
-    "    return 1.-2*rho\n",
-    "\n",
-    "def plot_riemann_traffic(rho_l,rho_r,t,xrange=1.):\n",
-    "    states, speeds, reval, wave_types = \\\n",
-    "            traffic_LWR.riemann_traffic_exact(rho_l,rho_r)\n",
-    "    ax = riemann_tools.plot_riemann(states,speeds,reval,\n",
-    "                                    wave_types,t=t,\n",
-    "                                    t_pointer=0,extra_axes=True,\n",
-    "                                    variable_names=['Density'],\n",
-    "                                    xmax=xrange);\n",
-    "    riemann_tools.plot_characteristics(reval,c,axes=ax[0])\n",
-    "    traffic_LWR.plot_car_trajectories(rho_l,rho_r,ax[2],t=t,xmax=xrange);\n",
-    "    ax[1].set_ylim(-0.05,1.05); ax[2].set_ylim(0,1)\n",
-    "    for a in ax:\n",
-    "        a.set_xlim(-xrange,xrange)\n",
-    "    plt.show()    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_riemann_traffic(0.2,0.4,t=0.5)"
+    "traffic_LWR.plot_riemann_traffic(0.2,0.4,t=0.5)"
    ]
   },
   {
@@ -341,7 +251,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_riemann_traffic(0.4,0.2,t=0.5)"
+    "traffic_LWR.plot_riemann_traffic(0.4,0.2,t=0.5)"
    ]
   },
   {
@@ -367,7 +277,8 @@
    "source": [
     "## Interactive Riemann solution\n",
     "\n",
-    "Code provided in the interactive notebooks solves the Riemann problem for any inputs $(\\rho_l,\\rho_r)$ with slider bars to adjust these. The characteristics and vehicle trajectories are also plotted."
+    "Throughout this notebook we have been using code from [traffic_LWR.py](./exact_solvers/traffic_LWR.py) to provide the exact solution of the Riemann problem.  In the interactive notebook, the interactive module below shows the solution\n",
+    "of the Riemann problem for any inputs $(\\rho_l,\\rho_r)$ with slider bars to adjust these. The characteristics and vehicle trajectories are also plotted."
    ]
   },
   {
@@ -380,68 +291,7 @@
    },
    "outputs": [],
    "source": [
-    "def riemann_traffic_exact(rho_l,rho_r):\n",
-    "    r\"\"\"Exact solution to the Riemann problem \n",
-    "    for the LWR traffic model.\n",
-    "    \n",
-    "    Returns reval, a function that gives the similarity\n",
-    "    solution as a function of xi = x/t.\"\"\"\n",
-    "    f = lambda rho: rho*(1-rho)\n",
-    "    if rho_r > rho_l: # Shock wave\n",
-    "        shock_speed = (f(rho_l)-f(rho_r))/(rho_l-rho_r)\n",
-    "        def reval(xi):\n",
-    "            if xi < shock_speed:\n",
-    "                return rho_l\n",
-    "            else:\n",
-    "                return rho_r\n",
-    "    else: # Rarefaction wave\n",
-    "        c_l  = 1-2*rho_l\n",
-    "        c_r = 1-2*rho_r\n",
-    "\n",
-    "        def reval(xi):\n",
-    "            if xi < c_l:\n",
-    "                return rho_l\n",
-    "            elif xi > c_r:\n",
-    "                return rho_r\n",
-    "            else:\n",
-    "                return (1.-xi)/2.      \n",
-    "    return reval"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "source": [
-    "The cell below generates a plot that shows the Riemann solution, along with characteristics and vehicle trajectories, for any inputs $(\\rho_l,\\rho_r)$."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "rho_l_widget = widgets.FloatSlider(min=0., max=1., value=0.5, description=r'$\\rho_l$')\n",
-    "rho_r_widget = widgets.FloatSlider(min=0., max=1., value=0., description=r'$\\rho_r$')\n",
-    "t_widget = widgets.FloatSlider(min=0., max=1., value=0.1)\n",
-    "x_range_widget = widgets.FloatSlider(min=0.1,max=5,value=1.,description=r'x-axis range')\n",
-    "params = widgets.HBox([t_widget,widgets.VBox([rho_l_widget,rho_r_widget]),x_range_widget])\n",
-    "\n",
-    "traffic_widget = interact(plot_riemann_traffic,\n",
-    "         rho_l=rho_l_widget, rho_r=rho_r_widget,\n",
-    "         t=t_widget,xrange=x_range_widget);\n",
-    "if traffic_widget:  # Avoid crash when using snapshot_widgets\n",
-    "    traffic_widget.widget.close()\n",
-    "    display(params)\n",
-    "    display(traffic_widget.widget.out)"
+    "traffic_LWR.riemann_solution_interact()"
    ]
   },
   {
@@ -455,9 +305,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/exact_solvers/traffic_LWR.py
+++ b/exact_solvers/traffic_LWR.py
@@ -2,6 +2,10 @@ import numpy as np
 import sys
 sys.path.append('../utils')
 from utils import riemann_tools
+import matplotlib.pyplot as plt
+from ipywidgets import widgets, FloatSlider
+from ipywidgets import interact
+
 
 def riemann_traffic_exact(q_l,q_r):
     r"""Exact solution to the Riemann problem for the LWR traffic model."""
@@ -54,3 +58,37 @@ def plot_car_trajectories(q_l,q_r,ax=None,t=None,xmax=None):
     riemann_tools.plot_riemann_trajectories(x_traj, t_traj, speeds, wave_types, 
             xmax=xmax, ax=ax, t=t)
     ax.set_title('Vehicle trajectories')
+
+def c(rho, xi):
+    "Characteristic speed."
+    return 1.-2*rho
+
+def plot_riemann_traffic(rho_l,rho_r,t,xrange=1.):
+    states, speeds, reval, wave_types = \
+            riemann_traffic_exact(rho_l,rho_r)
+    ax = riemann_tools.plot_riemann(states,speeds,reval,
+                                    wave_types,t=t,
+                                    t_pointer=0,extra_axes=True,
+                                    variable_names=['Density'],
+                                    xmax=xrange)
+    riemann_tools.plot_characteristics(reval,c,axes=ax[0])
+    plot_car_trajectories(rho_l,rho_r,ax[2],t=t,xmax=xrange)
+    ax[1].set_ylim(-0.05,1.05); ax[2].set_ylim(0,1)
+    for a in ax:
+        a.set_xlim(-xrange,xrange)
+    plt.show()
+
+def riemann_solution_interact():
+    rho_l_widget = widgets.FloatSlider(min=0., max=1., value=0.5, description=r'$\rho_l$')
+    rho_r_widget = widgets.FloatSlider(min=0., max=1., value=0., description=r'$\rho_r$')
+    t_widget = widgets.FloatSlider(min=0., max=1., value=0.1)
+    x_range_widget = widgets.FloatSlider(min=0.1,max=5,value=1.,description=r'x-axis range')
+    params = widgets.HBox([t_widget,widgets.VBox([rho_l_widget,rho_r_widget]),x_range_widget])
+
+    traffic_widget = interact(plot_riemann_traffic,
+             rho_l=rho_l_widget, rho_r=rho_r_widget,
+             t=t_widget,xrange=x_range_widget);
+    if traffic_widget:  # Avoid crash when using snapshot_widgets
+        traffic_widget.widget.close()
+        display(params)
+        display(traffic_widget.widget.out)

--- a/exact_solvers/traffic_demos.py
+++ b/exact_solvers/traffic_demos.py
@@ -1,0 +1,47 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from . import traffic_LWR
+figsize =(8,4)
+
+def plot_flux(fun):
+    plt.figure(figsize=(4,2))
+    rho = np.linspace(0,1)
+    f = fun(rho)
+    plt.plot(rho,f,linewidth=2)
+    plt.xlabel(r'$\rho$')
+    plt.ylabel(r'flux $f(\rho) = \rho(1-\rho)$')
+    plt.ylim(0,0.3)
+    plt.xlim(0,1); plt.grid(linestyle='--')
+
+def jam(rho_l=0.4,t=0.1):
+    shock_speed = -rho_l
+    shock_location = t*shock_speed
+    _, axes = plt.subplots(1,2,figsize=figsize)
+    
+    axes[0].plot([-1,shock_location],[rho_l,rho_l],'k',lw=2)
+    axes[0].plot([shock_location,shock_location],[rho_l,1.],'k',lw=2)
+    axes[0].plot([shock_location,1.],[1.,1.],'k',lw=2)
+    axes[0].set_xlabel('$x$'); axes[0].set_ylabel(r'$\rho$')
+    axes[0].set_xlim(shock_speed,-shock_speed); axes[0].set_ylim(0,1.1)
+    traffic_LWR.plot_car_trajectories(rho_l,1.,axes[1],t=t)
+    axes[1].set_ylim(0,1); axes[1].set_xlim(-0.6,0.6)
+    axes[0].set_title(r'$t= $'+str(t))
+    plt.xlabel('$x$'); plt.ylabel(r'$t$')
+    plt.show()  
+
+def green_light(rho_r=0.,t=0.1):
+    rho_l = 1.
+    left_edge = -t
+    right_edge = -t*(2*rho_r - 1)
+    fig, axes = plt.subplots(1,2,figsize=figsize)
+    axes[0].plot([-1,left_edge],[rho_l,rho_l],'k',lw=2)
+    axes[0].plot([left_edge,right_edge],[rho_l,rho_r],'k',lw=2)
+    axes[0].plot([right_edge,1.],[rho_r,rho_r],'k',lw=2)
+    axes[0].set_xlabel('$x$'); axes[0].set_ylabel(r'$\rho$');
+    axes[0].set_xlim(-1,1);  axes[0].set_ylim(-0.1,1.1)
+    axes[0].set_title('Solution')
+    plt.xlabel('$x$'); plt.ylabel(r'$t$');
+   
+    traffic_LWR.plot_car_trajectories(1.,rho_r,axes[1],t=t,xmax=1.); 
+    axes[1].set_ylim(0,1)
+    plt.show()


### PR DESCRIPTION
For the moment, `traffic_demos.py` is in the `exact_solvers` folder.  I tried putting it in a parallel folder called `demos`, but then it was more difficult to import.  I think we would need to add an `__init__.py` in the base `riemann_book` folder (so that the whole book is a Python package) and then readers would need to add the folder above `riemann_book` to their python path, or we would need to have Python actually install the package to a system folder.  I wasn't sure that we wanted to add that additional installation requirement.  It seems simpler to have the exact solvers and the demos in separate files in the same folder.  Perhaps we could rename the folder to `solvers_and_demos` or something similar.  In any case, I think it's okay to merge this PR and decide later on the directory structure.