### PR TITLE
WIP: revert to local JSAnimation

### DIFF
--- a/Nonconvex_scalar.ipynb
+++ b/Nonconvex_scalar.ipynb
@@ -4,9 +4,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Nonconvex scalar Conservation Laws and the Osher Solution\n",
+    "# Nonconvex scalar Conservation Laws"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The scalar nonlinear conservation law $q_t + f(q)_x = 0$ is said to be \"genuinely nonlinear\" over some range of states between $q_l$ and $q_r$ if $f''(q) \\neq 0$ for all $q$ between these values.  This is true in particular if $f(q)$ is any quadratic function, for example the flux function for Burgers' equation and the LWR traffic flow model are genuinely nonlinear for all $q$.  The reason this is important is that it means that the characteristic speed $f'(q)$ is either monotonically increasing or monotonically decreasing over the interval between $q_l$ and $q_r$.  As discussed already in chapters [Burgers.ipynb](Burgers.ipynb) and [Traffic_flow.ipynb](Traffic_flow.ipynb), if $f'(q)$ is increasing as $q$ varies from $q_l$ to $q_r$ then the initial discontinuity of a Riemann problem spreads out into a smooth single-valued rarefaction wave.  On the other hand if $f'(q)$ is decreasing then the discontinuity propagates as a single shock wave with speed given by the Rankine-Hugoniot condition.  Hence the Riemann solution for a genuinely nonlinear scalar equation always consists of either a single rarefaction wave or a single shock.\n",
     "\n",
-    "This chapter presents the implementation of Osher's general solution to the scalar nonlinear Riemann problem that is valid also for non-convex fluxes, using the formula from <cite data-cite=\"osher1984\"><a href=\"riemann.html#osher1984\">(Osher 1984)</a></cite>:\n",
+    "The solution can be much more complicated if $f''(q)$ vanishes somewhere between $q_l$ and $q_r$, since this means that the characteristic speed may not vary monotonically.  As we will illustrate below, for a scalar conservation law of this type the solution to the Riemann problem might consist of multiple shocks and rarefaction waves.  These waves all originate from $x=0$ and the Riemann solution is still a similarity solution $q(x,t) = Q(x/t)$ for some single-valued function $Q(\\xi)$, but determining the right set of waves is more challenging.  Below we present results computed using an elegant form of the solution to general scalar conservation laws due to Osher."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linear degeneracy\n",
+    "\n",
+    "The opposite extreme of genuine nonlinearity is \"linear degeneracy\".  The scalar advection equation has $f(q) = aq$ with constant characteristic speed $f'(q)\\equiv a$ and so $f''(q) \\equiv 0$ for all values of $q$.  Since it is a linear equation, it naturally fails to be genuinely nonlinear over any range of $q$ values.\n",
+    "\n",
+    "Recall that in the Riemann solution for the scalar advection equation (discussed in [Advection.ipynb](Advection.ipynb)) the characteristics are parallel to the propagating discontinuity in the $x$-$t$ plane.  They are neither impinging on the discontinuity (as in a shock wave, where the characteristic speed decreases from $q_l$ to $q_r$) nor are they spreading out (as they would in a rarefaction wave with $f'(q)$ increasing).  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Implications to systems of equations\n",
+    "\n",
+    "For hyperoblic systems of $m$ equations, there are $m$ different characteristic fields. For classical nonlinear systems such as the shallow water equations or the Euler equations of gas dynamics, the Riemann solution generally consists of $m$ waves, each of which is either a discontinuity or a rarefaction wave.  The fact that there is only one wave in each family results from the fact that, for these systems, each characteristic speed either varies monotonically through the wave (if the field is genuinely nonlinear) or else is constant across the wave (if the field is linearly degenerate).  In the former case the wave is either a single shock or rarefaction wave, and in the latter case the wave is a \"contact discontinuity\", as discussed further in [Shallow_water_tracer](Shallow_water_tracer.ipynb) and [Euler.ipynb](Euler.ipynb).  As in the case of scalar advection, the characteristic speed is constant across a contact discontinuity ($f'(q) \\equiv 0$ between the left and right states). The definition of genuine nonlinearity and linear degeneracy for systems of equations is given in [Shallow_water_tracer](Shallow_water_tracer.ipynb).\n",
+    "\n",
+    "The nonconvex equations studied in this chapter illustrate that even for a scalar problem the Riemann solution becomes much more complicated if the problem fails to be genuinely nonlinear or linearly degenerate.  *Systems* of equations that lack the corresponding properties are more difficult still and are beyond the scope of this book, although they do arise in some important applcations, such as magnetohydrodynamics (MHD)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Osher's Solution\n",
+    "\n",
+    "In this chapter we use Osher's general solution to the scalar nonlinear Riemann problem (valid also for non-convex fluxes), using the formula from <cite data-cite=\"osher1984\"><a href=\"riemann.html#osher1984\">(Osher 1984)</a></cite>.  The Riemann solution is always a similarity solution $q(x,t) = Q(x/t)$ for all $t>0$ (constant on any ray $x=\\alpha t$ eminating from the origin, for any constant $\\alpha$).  The function $Q(\\xi)$ is given by\n",
     "\n",
     "$$\n",
     "Q(\\xi) = \\begin{cases} \n",
@@ -15,33 +53,15 @@
     "\\end{cases}\n",
     "$$\n",
     "\n",
-    "See also Section 16.1 of <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)</a></cite>.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*[Add some more general discussion of non-convex fluxes.]*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Define a function returning the  Osher solution\n",
+    "Recall that $\\text{argmin}_{q_l \\leq q \\leq q_r} G(q)$ returns the value of $q$ for which $G(q)$ is minimized over the indicated interval, while argmax returns the value of $q$ where $G(q)$ is maximized.\n",
     "\n",
-    "We first define a function that can be used for any flux function $f(q)$ and left and right states. It returns the the single-valued Riemann solution consisting of shocks and rarefaction waves, and also returned the possibly multi-valued solution that would be obtained by tracing characteristics without regard to shock formation.\n",
-    "\n",
-    "You can jump over the next few code cells if you just want to explore some examples of nonconvex problems."
+    "For more discussion, see also Section 16.1 of <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)</a></cite>."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "hide"
     ]
@@ -49,237 +69,37 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "from __future__ import print_function\n",
+    "%config InlineBackend.figure_format = 'svg'\n",
+    "import seaborn as sns\n",
+    "sns.set_style('white',{'legend.frameon':'True'});\n",
+    "import matplotlib as mpl\n",
+    "mpl.rcParams['font.size'] = 10\n",
+    "figsize =(8,4)\n",
+    "mpl.rcParams['figure.figsize'] = figsize\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from IPython.display import display\n",
     "from ipywidgets import widgets, fixed\n",
     "from ipywidgets import interact\n",
     "from utils import riemann_tools\n",
-    "import numpy as np"
+    "from exact_solvers import nonconvex\n",
+    "from exact_solvers import nonconvex_demos"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The next cell defines a function that evaluates the Osher solution, and returns that function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def osher_solution(f, q_left, q_right, n=1000):\n",
-    "    \"\"\"\n",
-    "    Compute the Riemann solution to a scalar conservation law.\n",
-    "    \n",
-    "    Compute the similarity solution Q(x/t) and also the \n",
-    "    (possibly multi-valued) solution determined by tracing \n",
-    "    characteristics.\n",
-    "    \n",
-    "    Input:\n",
-    "      f = flux function (possibly nonconvex)\n",
-    "      q_left, q_right = Riemann data\n",
-    "      \n",
-    "    Returns:\n",
-    "      qtilde = function of xi = x/t giving the Riemann solution\n",
-    "    \"\"\"\n",
-    "\n",
-    "    from numpy import linspace,empty,argmin,argmax\n",
-    "    \n",
-    "    q_min = min(q_left, q_right)\n",
-    "    q_max = max(q_left, q_right)\n",
-    "    qv = linspace(q_min, q_max, n)\n",
-    "    \n",
-    "    # define the function qtilde as in (16.7)\n",
-    "    if q_left <= q_right:\n",
-    "        def qtilde(xi):\n",
-    "            Q = empty(xi.shape, dtype=float)\n",
-    "            for j,xij in enumerate(xi):\n",
-    "                i = argmin(f(qv) - xij*qv)\n",
-    "                Q[j] = qv[i]\n",
-    "            return Q\n",
-    "    else:\n",
-    "        def qtilde(xi):\n",
-    "            Q = empty(xi.shape, dtype=float)\n",
-    "            for j,xij in enumerate(xi):\n",
-    "                i = argmax(f(qv) - xij*qv)\n",
-    "                Q[j] = qv[i]\n",
-    "            return Q\n",
-    "    \n",
-    "    return qtilde"
+    "If you wish to examine the Python code for this chapter, please see:\n",
+    " - [exact_solvers/nonconvex.py](exact_solvers/nonconvex.py)\n",
+    " - [exact_solvers/nonconvex_demos.py](exact_solvers/nonconvex_demos.py)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the function `osher_solution` we define a function `nonconvex_solutions` that evaluates this solution at a set of `xi = x/t` values.  It also computes the possibly multi-valued solution that would be obtained by tracing characteristics, for plotting purposes.  An additional function `make_plot_function` returns a plotting function for use in interactive widgets below.  "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "def nonconvex_solutions(f, q_left, q_right, xi_left=None, xi_right=None):\n",
-    "    \"\"\"\n",
-    "    Compute the Riemann solution to a scalar conservation law.\n",
-    "    \n",
-    "    Compute the similarity solution Q(x/t) and also the \n",
-    "    (possibly multi-valued) solution determined by tracing \n",
-    "    characteristics.\n",
-    "    \n",
-    "    Input:\n",
-    "      f = flux function (possibly nonconvex)\n",
-    "      q_left, q_right = Riemann data\n",
-    "      xi_left, xi_right = optional left and right limits for xi = x/t\n",
-    "               in similarity solution.\n",
-    "               If not specified, chosen based on the characteristic speeds.\n",
-    "    \n",
-    "    Returns:\n",
-    "      xi = array of values between xi_left and xi_right\n",
-    "      q  = array of corresponding q(xi) values (xi = x/t)\n",
-    "      q_char = array of values of q between q_left and q_right\n",
-    "      xi_char = xi value for each q_char for use in plotting the\n",
-    "              (possibly multi-valued) solution where each q value\n",
-    "              propagates at speed f'(q).\n",
-    "    \"\"\"\n",
-    "    \n",
-    "    from numpy import linspace,empty,argmin,argmax,diff,hstack\n",
-    "    \n",
-    "    qtilde = osher_solution(f, q_left, q_right)\n",
-    "    \n",
-    "    q_min = min(q_left, q_right)\n",
-    "    q_max = max(q_left, q_right)\n",
-    "    qv = linspace(q_min, q_max, 1000)\n",
-    "    \n",
-    "     \n",
-    "    xi = linspace(xi_left, xi_right, 1000)\n",
-    "    q = qtilde(xi)\n",
-    "    \n",
-    "    # The rest is just for plotting purposes:\n",
-    "    fv = f(qv)\n",
-    "    dfdq = diff(fv) / (qv[1] - qv[0])\n",
-    "    dfdq_min = dfdq.min()\n",
-    "    dfdq_max = dfdq.max()\n",
-    "    dfdq_range = dfdq_max - dfdq_min\n",
-    "    \n",
-    "    #print(\"Mininum characteristic velocity: %g\" % dfdq_min)\n",
-    "    #print(\"Maximum characteristic velocity: %g\" % dfdq_max)\n",
-    "    \n",
-    "    if xi_left is None: \n",
-    "        xi_left = min(0,dfdq_min) - 0.1*dfdq_range\n",
-    "    if xi_right is None: \n",
-    "        xi_right = max(0,dfdq_max) + 0.1*dfdq_range\n",
-    "        \n",
-    "    q_char = hstack((q_min, 0.5*(qv[:-1] + qv[1:]), q_max))\n",
-    "    \n",
-    "    if q_left <= q_right:\n",
-    "        xi_min = xi_left\n",
-    "        xi_max = xi_right\n",
-    "    else:\n",
-    "        xi_min = xi_right\n",
-    "        xi_max = xi_left\n",
-    "   \n",
-    "    xi_char = hstack((xi_min, dfdq, xi_max))\n",
-    "    \n",
-    "    return xi, q, q_char, xi_char\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def plot_waves(f,q_left, q_right, xi_left, xi_right, n=1000, axes=None, t=0.2):\n",
-    "    qtilde = osher_solution(f, q_left, q_right, 3*n)\n",
-    "    xi = np.linspace(-2, 2, n)\n",
-    "    qvals = qtilde(xi)\n",
-    "    fvals = f(qvals)\n",
-    "    dxi = xi[1]-xi[0]\n",
-    "    smoothness = riemann_tools.detect_smoothness(qvals,dxi,dmax=10)\n",
-    "    values, ranges = riemann_tools.intervals(smoothness)\n",
-    "    wave_types, speeds = riemann_tools.make_waves(values, ranges, xi)\n",
-    "    riemann_tools.plot_waves(None,speeds,None,wave_types,ax=axes,t_pointer=False,t=t)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "source": [
-    "We also define a function that creates a `plot_function` useful in creating plots of the solutions below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "def make_plot_function(f, q_left, q_right, xi_left, xi_right):\n",
-    "    \n",
-    "    xi, qxi, q_char, xi_char = nonconvex_solutions(f, q_left, q_right, \n",
-    "                                              xi_left, xi_right)\n",
-    "    def plot_function(t=0.2, fig=0):\n",
-    "        \"\"\"\n",
-    "        Create plot at time t.\n",
-    "        Nonzero fig is used only by jsanimate_widgets when\n",
-    "        converting to html files.\n",
-    "        \"\"\"\n",
-    "        if fig==0: \n",
-    "            plt.figure(figsize=(14,6))\n",
-    "            \n",
-    "        # plot solution q(x,t):\n",
-    "        plt.subplot(1,3,1)\n",
-    "        # from characteristic-based solution:\n",
-    "        plt.plot(xi_char*t,q_char,'k--') \n",
-    "\n",
-    "        # single-valued solution, extended full domain:\n",
-    "        xi_plot = np.hstack((xi_left,xi*t,xi_right))\n",
-    "        q_plot = np.hstack((q_left,qxi,q_right))\n",
-    "        plt.plot(xi_plot, q_plot, 'k', linewidth=2)\n",
-    "        plt.title('Solution q(x,t) at t = %4.2f' % t)\n",
-    "        plt.xlabel('x')\n",
-    "\n",
-    "        plt.xlim(xi_left,xi_right)\n",
-    "        \n",
-    "        # plot flux function and convex hull:\n",
-    "        plt.subplot(1,3,3)\n",
-    "        q_plot = np.linspace(q_left, q_right, 1000)\n",
-    "        f_plot = f(q_plot)\n",
-    "        plt.plot(q_plot, f_plot, 'k--', label='f(q)')\n",
-    "        plt.plot(qxi, f(qxi),'k', label='Convex hull')\n",
-    "        plt.plot([q_left,q_right],[f(q_left),f(q_right)],'bo')\n",
-    "        plt.title('Flux function')\n",
-    "        plt.xlabel('q')\n",
-    "        plt.legend()\n",
-    "\n",
-    "        ax = plt.subplot(1,3,2)\n",
-    "        plot_waves(f,q_left,q_right,xi_left,xi_right,n=1000,axes=ax,t=t)\n",
-    "        ax.set_xlim(xi_left,xi_right)\n",
-    "        \n",
-    "        if fig==0: plt.show()\n",
-    "        return None\n",
-    "    return plot_function"
+    "Note that in [exact_solvers/nonconvex.py](exact_solvers/nonconvex.py) we use the function `osher_solution` to define a function `nonconvex_solutions` that evaluates this solution at a set of `xi = x/t` values.  It also computes the possibly multi-valued solution that would be obtained by tracing characteristics, for plotting purposes.  In [exact_solvers/nonconvex_demos.py](exact_solvers/nonconvex_demos.py), an additional function `make_plot_function` returns a plotting function for use in interactive widgets below.  "
    ]
   },
   {
@@ -288,7 +108,30 @@
    "source": [
     "## Traffic flow\n",
     "\n",
-    "First try a convex flux, such as $f(q) = q(1-q)$ from traffic flow (with $q$ now representing the density $\\rho$ that was used in [Traffic_flow.ipynb](Traffic_flow.ipynb))."
+    "First we recall that the Riemann solution for a convex flux consists of a single shock or rarefaction wave.  For example, consider the flux function $f(q) = q(1-q)$ from traffic flow (with $q$ now representing the density $\\rho$ that was used in [Traffic_flow.ipynb](Traffic_flow.ipynb))."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nonconvex_demos.demo1()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plot on the left above shows a case where the solution is a rarefaction wave that can be computed by tracing characteristics.  On the right we see the case for which tracing characteristics would give an multivalued solution (as a dashed line) whereas the correct Riemann solution consists of a shock wave (solid line)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For comparison with later examples, we also plot the quadratic flux function $f(q)$ and the linear characteristic speed $f'(q)$ for this range of $q$ values.  Plotting $q$ vs. the characteristic speed shows how we can interpret each value of $q$ in the jump discontinuity (represented by the dashed vertical line in the plot on the right below) as propagating to the left or right at its characteristic speed.  Since $f'(q)$ is linear in $q$, the rarefaction wave shown above is piecewise linear. "
    ]
   },
   {
@@ -298,32 +141,9 @@
    "outputs": [],
    "source": [
     "f = lambda q: q*(1-q)\n",
-    "\n",
-    "plt.figure(figsize=(12,5))\n",
-    "plt.subplot(121)\n",
-    "\n",
-    "q_left = 0.6;  q_right = 0.1\n",
-    "xi, qxi, q_char, xi_char = nonconvex_solutions(f, q_left, q_right, -1.5,1.5)\n",
-    "plt.plot(xi_char, q_char,'r')\n",
-    "plt.plot(xi, qxi, 'k', linewidth=2)\n",
-    "plt.ylim(0.,0.7)\n",
-    "plt.title('Rarefaction solution')\n",
-    "\n",
-    "plt.subplot(122)\n",
-    "\n",
-    "q_left = 0.1;  q_right = 0.6\n",
-    "xi, qxi, q_char, xi_char = nonconvex_solutions(f, q_left, q_right, -1.5,1.5)\n",
-    "plt.plot(xi_char, q_char,'k--')\n",
-    "plt.plot(xi, qxi, 'k', linewidth=2)\n",
-    "plt.ylim(0.,0.7)\n",
-    "plt.title('Shock solution');"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The plot on the left above shows a case where the solution is a rarefaction wave that can be computed by tracing characteristics.  On the right we see the case for which tracing characteristics would give an multivalued solution (as a dashed line) whereas the correct Riemann solution consists of a shock wave (solid line)."
+    "q_left = 0.1\n",
+    "q_right = 0.6\n",
+    "nonconvex_demos.plot_flux(f, q_left, q_right)"
    ]
   },
   {
@@ -350,7 +170,6 @@
    "source": [
     "a = 0.5\n",
     "f_buckley_leverett = lambda q: q**2 / (q**2 + a*(1-q)**2)\n",
-    "\n",
     "q_left = 1.\n",
     "q_right = 0."
    ]
@@ -366,48 +185,29 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "hide"
     ]
    },
    "outputs": [],
    "source": [
-    "qvals = np.linspace(q_right, q_left, 200)\n",
-    "fvals = f_buckley_leverett(qvals)\n",
-    "dfdq = np.diff(fvals) / (qvals[1]-qvals[0])  # approximate df/dq\n",
-    "qmid = 0.5*(qvals[:-1] + qvals[1:])   # midpoints for plotting dfdq\n",
-    "\n",
-    "plt.figure(figsize=(12,4))\n",
-    "plt.subplot(131)\n",
-    "plt.plot(qvals,fvals)\n",
-    "plt.xlabel('q')\n",
-    "plt.ylabel('f(q)')\n",
-    "plt.title('flux function f(q)')\n",
-    "\n",
-    "plt.subplot(132)\n",
-    "plt.plot(qmid, dfdq)\n",
-    "plt.xlabel('q')\n",
-    "plt.ylabel('df/dq')\n",
-    "plt.title('characteristic speed df/dq')\n",
-    "\n",
-    "plt.subplot(133)\n",
-    "plt.plot(dfdq, qmid)\n",
-    "plt.xlabel('df/dq')\n",
-    "plt.ylabel('q')\n",
-    "plt.title('q vs. df/dq')\n",
-    "\n",
-    "plt.subplots_adjust(left=0.)\n",
-    "plt.tight_layout()"
+    "nonconvex_demos.plot_flux(f_buckley_leverett, q_left, q_right)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the third plot above shows $q$ on the vertical axis and $df/dq$ on the horizontal axis (it's the middle figure turned sideways).  You can think of this as showing the characteristic velocity for each point on a jump discontinuity from $q=0$ to $q=1$, and hence a triple valued solution of the Riemann problem at $t=1$ when each $q$ value has propagated this far.  \n",
+    "Again the third plot above shows $q$ on the vertical axis and $f'(q)$ on the horizontal axis (it's the middle figure turned sideways).  You can think of this as showing the characteristic velocity for each point on a jump discontinuity from $q=0$ to $q=1$ (indicated by the dashed line), and hence a triple valued solution of the Riemann problem at $t=1$ when each $q$ value has propagated this far."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The correct Riemann solution\n",
     "\n",
-    "Below we show this together with the correct solution to the Riemann problem, with a shock wave inserted (as computed using the Osher solution defined above).  Note that for this non-convex flux function the Riemann solution consists partly of a rarefaction wave together with a shock wave.\n",
+    "Below we show this triple-valued solution together with the correct solution to the Riemann problem, with a shock wave inserted at the appropriate point (as computed using the Osher solution defined above).  Note that for this non-convex flux function the Riemann solution consists partly of a rarefaction wave together with a shock wave.\n",
     "\n",
     "In the plot on the right, we also show the flux function $f(q)$ as a red curve and the upper boundary of the convex hull of the set of points below the graph for $q_r \\leq q \\leq q_l$.  Note that the convex hull boundary follows the flux function for the set of $q$ values corresponding to the rarefaction wave and then jumps from $q\\approx 0.6$ to $q=0$, corresponding to the shock wave.  See Section 16.1 of <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)</a></cite> for more discussion of this construction of the Riemann solution."
    ]
@@ -420,7 +220,65 @@
    "source": [
     "q_left = 1.\n",
     "q_right = 0.\n",
-    "plot_function = make_plot_function(f_buckley_leverett, \n",
+    "plot_function = nonconvex_demos.make_plot_function(f_buckley_leverett, \n",
+    "                 q_left, q_right, xi_left=-2, xi_right=2)\n",
+    "\n",
+    "interact(plot_function, \n",
+    "         t=widgets.FloatSlider(value=0,min=0,max=.9),\n",
+    "         fig=fixed(0));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note from the plot on the left above that the triple-valued solution suggested by tracing characteristics (the dashed line) has been partially replaced by a shock wave.  By conservation, the areas of the two regions cut off by the shock must cancel out.  Moreover, the shock speed coincides with the characteristic speed along at the edge of the rarefaction wave that ends at the shock.  In terms of the flux function shown by the dashed curve in the right-most figure above, we see that the shock wave connects $q_r=0$ to the point where the slope of the solid line (the shock speed) agrees with the slope of the flux function (the characteristic speed at this edge of the rarefaction wave).  The correct Riemann solution lies along the upper convex hull of the flux function."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Swapping left and right states\n",
+    "Note what happens if we switch `q_left` and `q_right` in this problem.  This now corresponds to oil on the left pushing into water on the right.  Since $q_l < q_r$ in this case, the correct Riemann solution corresponds to the lower convex hull of the flux function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "q_left = 0.\n",
+    "q_right = 1.\n",
+    "plot_function = nonconvex_demos.make_plot_function(f_buckley_leverett, \n",
+    "                 q_left, q_right, xi_left=-2, xi_right=2)\n",
+    "\n",
+    "interact(plot_function, \n",
+    "         t=widgets.FloatSlider(value=0,min=0,max=.9),\n",
+    "         fig=fixed(0));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Leftward flow\n",
+    "Note that the Buckley-Leverett equation as written above simulates flow from left to right.   So if we wanted to model water on the right pushing leftward into oil on the left, we must negate the flux function, as is done in the next cell. Note that this gives the same solution as our original Riemann problem, but flipped in `x`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f_BL_leftward = lambda q: -f_buckley_leverett(q)\n",
+    "q_left = 0.\n",
+    "q_right = 1.\n",
+    "plot_function = nonconvex_demos.make_plot_function(f_BL_leftward, \n",
     "                 q_left, q_right, xi_left=-2, xi_right=2)\n",
     "\n",
     "interact(plot_function, \n",
@@ -434,23 +292,38 @@
    "source": [
     "## Sinusoidal flux\n",
     "\n",
-    "As another test, the flux function $f(q) = \\sin(q)$ is used in Example 16.1 of <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)</a></cite> to produce the Figure 16.4 in that book."
+    "As another test, the flux function $f(q) = \\sin(q)$ is used in Example 16.1 of <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)</a></cite>.\n",
+    "\n",
+    "First we plot the flux function $f(q)$ and also the characteristic speed $df/dq$. We also plot $q$ as a function of $df/dq$.  This again helps us visualize whether the characteristic speed is positive or negative for each value of $q$ along the jump discontinuity in the Riemann data (again indicated by the vertical dashed line), and shows that trying to solve the Riemann problem by tracing characteristics alone would lead to a multi-valued solution."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "f_sin = lambda q: np.sin(q)\n",
-    "\n",
     "q_left = np.pi/4.\n",
     "q_right = 15*np.pi/4.\n",
     "\n",
-    "plot_function = make_plot_function(f_sin, q_left, q_right, -1.5, 1.5)\n",
+    "nonconvex_demos.plot_flux(f_sin, q_left, q_right)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And here is a dynamic version of Figure 16.4 of <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)</a></cite>, illustrating where shocks must be inserted to make the Riemann solution single valued."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_function = nonconvex_demos.make_plot_function(f_sin, q_left, q_right, -1.5, 1.5)\n",
     "\n",
     "interact(plot_function, \n",
     "         t=widgets.FloatSlider(value=0.,min=0.,max=.9),\n",
@@ -463,23 +336,20 @@
    "source": [
     "In the figure above, note that the shocks in the Riemann solution correspond to linear segments of the lower boundary of the convex hull of the set of points that lie above the flux function $f(q)$.  This is because we chose $q_l < q_r$ in this example.\n",
     "\n",
-    "If we switch the states so that $q_l > q_r$, then as in the Buckley-Leverett example above, the Riemann solution corresponds to the upper boundary of the convex hull of the set of points that lie below the flux function:"
+    "If we switch the states so that $q_l > q_r$, then the Riemann solution corresponds to the upper boundary of the convex hull of the set of points that lie below the flux function:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "f_sin = lambda q: np.sin(q)\n",
-    "\n",
     "q_left = 15*np.pi/4.\n",
     "q_right = np.pi/4.\n",
     "\n",
-    "plot_function = make_plot_function(f_sin, q_left, q_right, -1.5, 1.5)\n",
+    "plot_function = nonconvex_demos.make_plot_function(f_sin, q_left, q_right, -1.5, 1.5)\n",
     "\n",
     "interact(plot_function, \n",
     "         t=widgets.FloatSlider(value=0.,min=0.,max=.9),\n",
@@ -492,7 +362,7 @@
    "source": [
     "## Yet another example\n",
     "\n",
-    "Here's another example where the flux function $f(q) = q\\sin(q)$ is even more oscillatory over the region $q_l \\leq q \\leq q_r$.  Note the collection of shock and rarefaction waves that result from this."
+    "Here's another example. Note the collection of shock and rarefaction waves that result from this."
    ]
   },
   {
@@ -501,24 +371,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f = lambda q: q*np.sin(q)\n",
-    "q_left = 2.\n",
-    "q_right = 22.\n",
+    "f = lambda q: 0.25*(1. - q)*np.sin(1.5*q)\n",
+    "q_left = -3.2\n",
+    "q_right = 3.6\n",
     "\n",
-    "plot_function = make_plot_function(f, q_left, q_right, -25,20)\n",
+    "plot_function = nonconvex_demos.make_plot_function(f, q_left, q_right, -3, 3)\n",
     "\n",
     "interact(plot_function, \n",
     "         t=widgets.FloatSlider(value=0.,min=0.,max=.9),\n",
     "         fig=fixed(0));"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_waves(f_sin,q_left,q_right,-5,5,n=100)"
    ]
   },
   {
@@ -527,7 +388,7 @@
    "source": [
     "What does the Riemann solution look like if you switch the left and right states in this example?\n",
     "\n",
-    "Experiment with other flux functions in this notebook!"
+    "Experiment with this and other flux functions in this notebook!  But please note that the plotting functions, as written, may break down if you try an example with too many oscillations in the flux."
    ]
   }
  ],
@@ -547,7 +408,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/exact_solvers/nonconvex.py
+++ b/exact_solvers/nonconvex.py
@@ -1,0 +1,111 @@
+import numpy as np
+import sys
+sys.path.append('../utils')
+from utils import riemann_tools
+import matplotlib.pyplot as plt
+from ipywidgets import widgets, FloatSlider
+from ipywidgets import interact
+
+def osher_solution(f, q_left, q_right, n=1000):
+    """
+    Compute the Riemann solution to a scalar conservation law.
+    
+    Compute the similarity solution Q(x/t) and also the 
+    (possibly multi-valued) solution determined by tracing 
+    characteristics.
+    
+    Input:
+      f = flux function (possibly nonconvex)
+      q_left, q_right = Riemann data
+      
+    Returns:
+      qtilde = function of xi = x/t giving the Riemann solution
+    """
+
+    from numpy import linspace,empty,argmin,argmax
+    
+    q_min = min(q_left, q_right)
+    q_max = max(q_left, q_right)
+    qv = linspace(q_min, q_max, n)
+    
+    # define the function qtilde as in (16.7)
+    if q_left <= q_right:
+        def qtilde(xi):
+            Q = empty(xi.shape, dtype=float)
+            for j,xij in enumerate(xi):
+                i = argmin(f(qv) - xij*qv)
+                Q[j] = qv[i]
+            return Q
+    else:
+        def qtilde(xi):
+            Q = empty(xi.shape, dtype=float)
+            for j,xij in enumerate(xi):
+                i = argmax(f(qv) - xij*qv)
+                Q[j] = qv[i]
+            return Q
+    
+    return qtilde
+
+def nonconvex_solutions(f, q_left, q_right, xi_left=None, xi_right=None):
+    """
+    Compute the Riemann solution to a scalar conservation law.
+    
+    Compute the similarity solution Q(x/t) and also the 
+    (possibly multi-valued) solution determined by tracing 
+    characteristics.
+    
+    Input:
+      f = flux function (possibly nonconvex)
+      q_left, q_right = Riemann data
+      xi_left, xi_right = optional left and right limits for xi = x/t
+               in similarity solution.
+               If not specified, chosen based on the characteristic speeds.
+    
+    Returns:
+      xi = array of values between xi_left and xi_right
+      q  = array of corresponding q(xi) values (xi = x/t)
+      q_char = array of values of q between q_left and q_right
+      xi_char = xi value for each q_char for use in plotting the
+              (possibly multi-valued) solution where each q value
+              propagates at speed f'(q).
+    """
+    
+    from numpy import linspace,empty,argmin,argmax,diff,hstack
+    
+    qtilde = osher_solution(f, q_left, q_right)
+    
+    q_min = min(q_left, q_right)
+    q_max = max(q_left, q_right)
+    qv = linspace(q_min, q_max, 1000)
+    
+     
+    xi = linspace(xi_left, xi_right, 1000)
+    q = qtilde(xi)
+    
+    # The rest is just for plotting purposes:
+    fv = f(qv)
+    dfdq = diff(fv) / (qv[1] - qv[0])
+    dfdq_min = dfdq.min()
+    dfdq_max = dfdq.max()
+    dfdq_range = dfdq_max - dfdq_min
+    
+    #print("Mininum characteristic velocity: %g" % dfdq_min)
+    #print("Maximum characteristic velocity: %g" % dfdq_max)
+    
+    if xi_left is None: 
+        xi_left = min(0,dfdq_min) - 0.1*dfdq_range
+    if xi_right is None: 
+        xi_right = max(0,dfdq_max) + 0.1*dfdq_range
+        
+    q_char = hstack((q_min, 0.5*(qv[:-1] + qv[1:]), q_max))
+    
+    if q_left <= q_right:
+        xi_min = xi_left
+        xi_max = xi_right
+    else:
+        xi_min = xi_right
+        xi_max = xi_left
+   
+    xi_char = hstack((xi_min, dfdq, xi_max))
+    
+    return xi, q, q_char, xi_char

--- a/exact_solvers/nonconvex_demos.py
+++ b/exact_solvers/nonconvex_demos.py
@@ -1,0 +1,151 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from . import nonconvex
+import sys
+sys.path.append('../utils')
+from utils import riemann_tools
+
+figsize =(8,4)
+
+def plot_waves(f,q_left, q_right, xi_left, xi_right, n=1000, axes=None, t=0.2):
+    qtilde = nonconvex.osher_solution(f, q_left, q_right, 1000)
+    xi = np.linspace(xi_left, xi_right, n)
+    qvals = qtilde(xi)
+    fvals = f(qvals)
+    dxi = xi[1]-xi[0]
+    #print('+++ qvals:\n',qvals)
+    #print('+++ dxi:\n',dxi)
+    smoothness = riemann_tools.detect_smoothness(qvals,dxi,dmax=10)
+    values, ranges = riemann_tools.intervals(smoothness)
+    #print('+++ smoothness:\n',smoothness)
+    #print('+++ values:\n',values)
+    #print('+++ ranges:\n',ranges)
+    
+    # filter out extraneous constant states between rarefactions:
+    jd = []
+    for j in range(len(values)):
+        try:
+            if values[j]==0 and values[j+1]==1 and values[j-1]==1:
+                jd.append(j)         
+        except:
+            pass
+    jd.reverse()
+    for j in jd:
+        ranges[j-1] = (ranges[j-1][0], ranges[j+1][1])  # merge
+        values.pop(j+1)
+        values.pop(j)
+        ranges.pop(j+1)
+        ranges.pop(j)  
+        
+        
+    #print('+++ values:\n',values)
+    #print('+++ ranges:\n',ranges)
+        
+
+    wave_types, speeds = riemann_tools.make_waves(values, ranges, xi)
+    riemann_tools.plot_waves(None,speeds,None,wave_types,ax=axes,
+                             t_pointer=False,t=t)
+    #plt.xlim(xi_left, xi_right)
+    plt.xlabel('x')
+
+def make_plot_function(f, q_left, q_right, xi_left, xi_right):
+    
+    xi, qxi, q_char, xi_char = nonconvex.nonconvex_solutions(f, q_left, q_right, 
+                                                             xi_left, xi_right)
+    def plot_function(t=0.2, fig=0):
+        """
+        Create plot at time t.
+        Nonzero fig is used only by jsanimate_widgets when
+        converting to html files.
+        """
+        if fig==0: 
+            #plt.figure(figsize=(14,6))
+            plt.figure()
+            
+        # plot solution q(x,t):
+        plt.subplot(1,3,1)
+        # from characteristic-based solution:
+        plt.plot(xi_char*t,q_char,'k--') 
+
+        # single-valued solution, extended full domain:
+        xi_plot = np.hstack((xi_left,xi*t,xi_right))
+        q_plot = np.hstack((q_left,qxi,q_right))
+        plt.plot(xi_plot, q_plot, 'k', linewidth=2)
+        plt.title('Solution q(x,t) at t = %4.2f' % t)
+        plt.xlabel('x')
+
+        plt.xlim(xi_left,xi_right)
+        
+        # plot flux function and convex hull:
+        plt.subplot(1,3,3)
+        q_plot = np.linspace(q_left, q_right, 1000)
+        f_plot = f(q_plot)
+        plt.plot(q_plot, f_plot, 'k--', label='f(q)')
+        plt.plot(qxi, f(qxi),'k', label='Convex hull')
+        plt.plot([q_left,q_right],[f(q_left),f(q_right)],'bo')
+        plt.title('Flux function')
+        plt.xlabel('q')
+        plt.legend()
+
+        ax = plt.subplot(1,3,2)
+        plot_waves(f,q_left,q_right,xi_left,xi_right,n=1000,axes=ax,t=t)
+        #ax.set_xlim(xi_left,xi_right)
+        
+        if fig==0: plt.show()
+        return None
+    return plot_function
+
+def demo1():
+    f = lambda q: q*(1-q)
+
+    #plt.figure(figsize=(12,5))
+    plt.subplot(121)
+
+    q_left = 0.6;  q_right = 0.1
+    xi, qxi, q_char, xi_char = nonconvex.nonconvex_solutions(f, q_left, q_right,
+                                                             -1.5,1.5)
+    plt.plot(xi_char, q_char,'r')
+    plt.plot(xi, qxi, 'k', linewidth=2)
+    plt.ylim(0.,0.7)
+    plt.title('Rarefaction solution')
+
+    plt.subplot(122)
+
+    q_left = 0.1;  q_right = 0.6
+    xi, qxi, q_char, xi_char = nonconvex.nonconvex_solutions(f, q_left, q_right,
+                                                             -1.5,1.5)
+    plt.plot(xi_char, q_char,'k--')
+    plt.plot(xi, qxi, 'k', linewidth=2)
+    plt.ylim(0.,0.7)
+    plt.title('Shock solution');
+    
+def plot_flux(f, q_left, q_right, plot_zero=True):
+    qvals = np.linspace(q_right, q_left, 200)
+    fvals = f(qvals)
+    dfdq = np.diff(fvals) / (qvals[1]-qvals[0])  # approximate df/dq
+    qmid = 0.5*(qvals[:-1] + qvals[1:])   # midpoints for plotting dfdq
+
+    #plt.figure(figsize=(12,4))
+    plt.subplot(131)
+    plt.plot(qvals,fvals)
+    plt.xlabel('q')
+    plt.ylabel('f(q)')
+    plt.title('flux function f(q)')
+
+    plt.subplot(132)
+    plt.plot(qmid, dfdq)
+    plt.xlabel('q')
+    plt.ylabel('df/dq')
+    plt.title('characteristic speed df/dq')
+
+    plt.subplot(133)
+    plt.plot(dfdq, qmid)
+    plt.xlabel('df/dq')
+    plt.ylabel('q')
+    plt.title('q vs. df/dq')
+    if plot_zero:
+        plt.plot([0,0],[qmid.min(), qmid.max()],'k--')
+
+    plt.subplots_adjust(left=0.)
+    plt.tight_layout()
+

--- a/exact_solvers/nonconvex_demos.py
+++ b/exact_solvers/nonconvex_demos.py
@@ -13,15 +13,15 @@ def plot_waves(f,q_left, q_right, xi_left, xi_right, n=1000, axes=None, t=0.2):
     qvals = qtilde(xi)
     fvals = f(qvals)
     dxi = xi[1]-xi[0]
-    #print('+++ qvals:\n',qvals)
-    #print('+++ dxi:\n',dxi)
     smoothness = riemann_tools.detect_smoothness(qvals,dxi,dmax=10)
     values, ranges = riemann_tools.intervals(smoothness)
-    #print('+++ smoothness:\n',smoothness)
-    #print('+++ values:\n',values)
-    #print('+++ ranges:\n',ranges)
     
     # filter out extraneous constant states between rarefactions:
+    # For complicated nonconvex fluxes, 
+    # values tend to contain sequences [1,0,1] indicating a constant
+    # state between two rarefaction waves, which shouldn't happen,
+    # so merge such ranges into a single rarefaction wave.
+    
     jd = []
     for j in range(len(values)):
         try:
@@ -36,11 +36,6 @@ def plot_waves(f,q_left, q_right, xi_left, xi_right, n=1000, axes=None, t=0.2):
         values.pop(j)
         ranges.pop(j+1)
         ranges.pop(j)  
-        
-        
-    #print('+++ values:\n',values)
-    #print('+++ ranges:\n',ranges)
-        
 
     wave_types, speeds = riemann_tools.make_waves(values, ranges, xi)
     riemann_tools.plot_waves(None,speeds,None,wave_types,ax=axes,

--- a/utils/animation_tools.py
+++ b/utils/animation_tools.py
@@ -2,8 +2,9 @@
 *NOTE:* This version is slightly modified from the one in
     $CLAW/visclaw/src/python/visclaw/animation_tools.py
 
-Some functions require JSAnimation, which is available in matplotlib
-version 2.1 and later.
+Some functions requires JSAnimation, either from Clawpack 
+or by installing it separately from
+    https://github.com/jakevdp/JSAnimation
 
 This animation_tools module contains tools to create animations in Python and
 Jupyter notebooks.
@@ -48,6 +49,16 @@ from matplotlib import image, animation
 from matplotlib import pyplot as plt
 from ipywidgets import interact, interact_manual
 import ipywidgets
+
+try:
+    from JSAnimation import IPython_display
+except:
+    try:
+        from clawpack.visclaw.JSAnimation import IPython_display
+    except:
+        print("*** Warning: JSAnimation not found")
+        
+
 
 def make_plotdir(plotdir='_plots', clobber=True):
     """
@@ -169,7 +180,16 @@ def make_html(anim, file_name='anim.html', title=None, raw_html='',
     Take an animation created by make_anim and convert it into a stand-alone
     html file.
     """
-    html_body = anim.to_jshtml(fps, embed_frames, default_mode)
+    try:
+        from JSAnimation.IPython_display import anim_to_html
+    except:
+        try:
+            from clawpack.visclaw.JSAnimation.IPython_display import anim_to_html
+        except:
+            print("*** Warning: JSAnimation not found, cannot import anim_to_html")
+
+    html_body = anim_to_html(anim, fps=fps, embed_frames=embed_frames, \
+                 default_mode=default_mode)
 
     html_file = open(file_name,'w')
     html_file.write("<html>\n <h1>%s</h1>\n" % title)
@@ -185,7 +205,16 @@ def make_rst(anim, file_name='anim.rst',
     Take an animation created by make_anim and convert it into an rst file
     (reStructuredText, for inclusion in Sphinx documentation, for example).
     """
-    rst_body = anim.to_jshtml()
+    try:
+        from JSAnimation.IPython_display import anim_to_html
+    except:
+        try:
+            from clawpack.visclaw.JSAnimation.IPython_display import anim_to_html
+        except:
+            print("*** Warning: JSAnimation not found, cannot import anim_to_html")
+
+    rst_body = anim_to_html(anim, fps=fps, embed_frames=embed_frames, \
+                 default_mode=default_mode)
 
     rst_body = rst_body.split('\n')
 


### PR DESCRIPTION
Because the version built into matplotlib seems to have problems.

- Not all animations play properly in html files
- Plots are greatly pixelated in the animations

I think this reverts back JSAnimation while preserving other more recent updates to `utils/animation_tools.py`.

I ran into problems testing it however -- I foolishly used the same conda environment to try to re-build the clawpack docs to fix the pyclaw issues there, and now the pyclaw Riemann solvers don't import properly any more (apparently due to numpy having been updated when I installed nbsphinx).  Such fun!

I'll work more on this later...

