### PR TITLE
fix figsizes in  Nonconvex_scalar by loading matplotlib in separate cell

### DIFF
--- a/Nonconvex_scalar.ipynb
+++ b/Nonconvex_scalar.ipynb
@@ -61,6 +61,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": [
      "hide"
@@ -68,7 +77,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "%config InlineBackend.figure_format = 'svg'\n",
     "#import seaborn as sns\n",
     "#sns.set_style('white',{'legend.frameon':'True'});\n",
@@ -365,7 +373,9 @@
    "source": [
     "## Yet another example\n",
     "\n",
-    "Here's another example. Note the collection of shock and rarefaction waves that result from this.  In the notebook you can adjust $q_l$ and $q_r$.  Notice how the structure of the solution changes as you vary them.  What do you think the Riemann solution looks like if you switch the left and right states?  Check if you are right."
+    "Here's another example that you can run in a live notebook. Note the collection of shock and rarefaction waves that result from this.  In the notebook you can adjust $q_l$ and $q_r$.  Notice how the structure of the solution changes as you vary them.  What do you think the Riemann solution looks like if you switch the left and right states?  Check if you are right.\n",
+    "\n",
+    "Note this example doesn't work in the static html version due to sliders for $q_l$ and $q_r$."
    ]
   },
   {
@@ -405,6 +415,18 @@
    "display_name": "Python 2",
    "language": "python",
    "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Also I added a comment that the last example doesn't work in the html version:  I think because of multiple sliders not converting to jsAnimation, this only works for a single time-slider.  Maybe we should figure out a way to handle other cases?

Hmm, I take it back.  For some reason the last time I created the new html file it did work, though it didn't previously. See http://www.clawpack.org/riemann_book/html/Nonconvex_scalar.html