### PR TITLE
Remove custom CSS in intro notebook.

### DIFF
--- a/Introduction.ipynb
+++ b/Introduction.ipynb
@@ -37,7 +37,19 @@
    "outputs": [],
    "source": [
     "context = 'notebook'\n",
-    "%matplotlib inline\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
     "%config InlineBackend.figure_format = 'svg'\n",
     "import matplotlib as mpl\n",
     "from exact_solvers import shallow_water\n",
@@ -52,37 +64,6 @@
     "    from utils.snapshot_widgets import interact\n",
     "import seaborn as sns\n",
     "sns.set_style('white',{'legend.frameon':'True'});"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "nbdime-conflicts": {
-     "local_diff": [
-      {
-       "key": "collapsed",
-       "op": "add",
-       "value": true
-      }
-     ],
-     "remote_diff": [
-      {
-       "key": "collapsed",
-       "op": "add",
-       "value": false
-      }
-     ]
-    },
-    "tags": [
-     "hide"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "from IPython.core.display import HTML\n",
-    "css_file = './custom.css'\n",
-    "HTML(open(css_file, \"r\").read())"
    ]
   },
   {
@@ -449,9 +430,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -466,10 +447,13 @@
    "version": "3.6.5"
   },
   "toc": {
+   "base_numbering": 1,
    "nav_menu": {},
    "number_sections": true,
    "sideBar": true,
    "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
    "toc_cell": false,
    "toc_position": {},
    "toc_section_display": "block",


### PR DESCRIPTION
In our last Skype call we agreed to not use custom CSS for the book; this removes it.

Also separate matplotlib inline into its own cell in the Introduction notebook.