### PR TITLE
Some wording and spacing changes in Burgers.ipynb

### DIFF
--- a/Burgers.ipynb
+++ b/Burgers.ipynb
@@ -147,7 +147,7 @@
    "outputs": [],
    "source": [
     "interact(burgers_demos.shock(), t=widgets.FloatSlider(value=0.0,min=0,max=1.0),\n",
-    "                    which_char=widgets.Checkbox(value=True,description='Show characteristics'));"
+    "         which_char=widgets.Checkbox(value=True,description='Show characteristics'));"
    ]
   },
   {
@@ -201,7 +201,7 @@
    "outputs": [],
    "source": [
     "interact(burgers_demos.rarefaction(), t=widgets.FloatSlider(value=0.0,min=0,max=1.0),\n",
-    "                    which_char=widgets.Checkbox(value=True,description='Show characteristics'));"
+    "         which_char=widgets.Checkbox(value=True,description='Show characteristics'));"
    ]
   },
   {
@@ -215,8 +215,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we mentioned before, the differential form of the equation breaks down in the presence of shocks/discontinuities. However, the integral form of the conservation law remains valid. We will derive a specific form of the integral conservation law that is particularly useful to prove mathematical results.\n",
-    "We first integrate the general conservation law $q_t+f(q)_x=0$ from from $x=x_1$ to $x=x_2$ and $t=t_1$ to $t=t_2$\n",
+    "As we mentioned before, the differential form of the equation breaks down in the presence of shocks/discontinuities. However, the integral form of the conservation law remains valid. We will derive a specific form of the integral conservation law that is particularly useful for proving mathematical results.\n",
+    "We first integrate the general conservation law $q_t+f(q)_x=0$ from $x=x_1$ to $x=x_2$ and $t=t_1$ to $t=t_2$\n",
     "\n",
     "\\begin{align}\n",
     "\\int_{t_1}^{t_2}\\int_{x_1}^{x_2} [q_t+f(q)_x] dx dt = 0,\n",
@@ -224,16 +224,17 @@
     "\\end{align}\n",
     "This integral can be rewritten in terms of an indicator function $\\phi(x,t)$ with compact support in $[x_1,x_2]\\times[t_1,t_2]$ (defined to be 1 in this region, zero elsewhere):\n",
     "\n",
-    "\\begin{align*}\n",
+    "\\begin{align}\n",
     "\\int_{0}^{\\infty}\\int_{-\\infty}^{\\infty} [q_t+f(q)_x]\\phi(x,t) dx dt = 0.\n",
-    "\\end{align*}\n",
+    "\\label{eq:infintclaw}\n",
+    "\\end{align}\n",
     "\n",
     "We can generalize this result by replacing $\\phi(x,t)$ by a smooth function with compact support on some region of the $x-t$ plane. In this case, integrating by parts yield\n",
     "\n",
     "\\begin{align*}\n",
     "\\int_{0}^{\\infty}\\int_{-\\infty}^{\\infty} [q\\phi_t+f(q)\\phi_x] dx dt = -\\int_{-\\infty}^{\\infty}q(x,0)\\phi(x,0)dx,\n",
     "\\end{align*}\n",
-    "where now the derivatives are on $\\phi(x,t)$ and not on $q$ or $f(q)$, so the equation still makes sense for discontinuous $q$. The function $q(x,t)$ is a weak solution of the conservation law if this equation holds for all functions $\\phi(x,t)$ that are continuously differentiable and with compact support (bump functions). Note this rules out the original interval chosen in Eq. \\ref{eq:Burgersintclaw} since its $\\phi$ would not be smooth. However, we can approximate this function arbitrarily well by a smooth function. Note any weak solution is a solution of any form of the integral conservation law and vice versa.\n",
+    "where now the derivatives are on $\\phi(x,t)$ and not on $q$ or $f(q)$, so the equation still makes sense for discontinuous $q$. The function $q(x,t)$ is a weak solution of the conservation law if this equation holds for all functions $\\phi(x,t)$ that are continuously differentiable and with compact support (bump functions). Note this rules out the indicator function $\\phi$ for which  (\\ref{eq:infintclaw}) reduces to (\\ref{eq:Burgersintclaw}), since this step function would not be smooth. However, we can approximate this function arbitrarily well by a smooth function. Note any weak solution is a solution of any form of the integral conservation law and vice versa.\n",
     "\n",
     "Weak solutions are thus allowed to include discontinuities.  The shock solution presented above, for instance, is a weak solution of the Burgers' equation.  After characteristics cross, we cannot have strong solutions of the conservation law, and we must resort to weak solutions. However, one given problem may have multiple weak solutions."
    ]
@@ -264,7 +265,7 @@
    "outputs": [],
    "source": [
     "interact(burgers_demos.unphysical(), t=widgets.FloatSlider(value=0.0,min=0,max=1.0),\n",
-    "                    which_char=widgets.Checkbox(value=True,description='Show characteristics'));"
+    "         which_char=widgets.Checkbox(value=True,description='Show characteristics'));"
    ]
   },
   {
@@ -285,7 +286,7 @@
     "$$\n",
     "f'(q_l) > f'(q_r).\n",
     "$$\n",
-    "In other words, the solution is a shock only if the characteristics are going into the shock as time progresses. If the characteristics are spreading out/going out of the shock as in the last example, one would naturally expect a rarefaction to be the correct solution. In the case of Burgers' equation, the flux function is $f(q)=q^2/2$, so the correct solution is a shock only if\n",
+    "In other words, the solution is a shock only if the characteristics are going into the shock as time progresses. If the characteristics are spreading out from the shock as in the last example, one would naturally expect a rarefaction to be the correct solution. In the case of Burgers' equation, the flux function is $f(q)=q^2/2$, so the correct solution is a shock only if\n",
     "\n",
     "$$\n",
     "q_l > q_r,\n",
@@ -328,7 +329,7 @@
    "metadata": {},
    "source": [
     "### Example 1: Bump initial condition\n",
-    "The animation below shows the solution of Burgers' equation for an initial Gaussian hump.  The solution is computed numerically using [PyClaw](http://www.clawpack.org/pyclaw/)."
+    "The animation below shows the solution of Burgers' equation for an initial Gaussian hump.  The solution is computed numerically using [PyClaw](http://www.clawpack.org/pyclaw/).  Note that initially the solution behaves as in the figure at the start of this chapter, with each value of $q$ propagating at speed $q$.  Once the front of the wave has steepened up and would become multivalued, a shock forms and propagates at a varying speed given by the Rankine-Hugoniot condition, slowing down as the peak diminishes."
    ]
   },
   {
@@ -420,7 +421,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
I really like the interacts in this notebook!

I wonder in this and other notebooks whether we plan to put the blocks of code setting things up at the top, or after the introductory material for the chapter?  I thought we had decided on the latter, e.g. as in `Nonconvex_scalar.ipynb`, but in the `Burgers.ipynb` and some others it cIomes first.

I replaced `Eq. \ref{eq:Burgersintclaw}` with `(\ref{eq:Burgersintclaw})` to be consistent with what is done some other places, although I see we also use `\eqref{eq:...}` some places, which seems to give a spurious period before the equation number (e.g. in `Acoustics.ipynb` both the above forms are used in different places).

I made a few other suggested changes to wording in this PR and removed some white space from `interact(...` commands that were too wide for my window.

I'm happy with this notebook!