### PR TITLE
Some suggestions to Euler_compare.ipynb

### DIFF
--- a/Euler_compare.ipynb
+++ b/Euler_compare.ipynb
@@ -11,10 +11,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "How do these solvers impact the solution accuracy when used within a finite volume discretization?  To investigate, we will use them within [PyClaw](http://www.clawpack.org/pyclaw/) to solve two standard test problems for one-dimensional compressible flow:\n",
+    "In [Euler_approximate_solvers.ipynb](Euler_approximate_solvers.ipynb) we introduced several approximate Riemann solvers for the Euler equations of compressible gas dynamics.  How do these solvers impact the solution accuracy when used within a finite volume discretization?  To investigate, we will use them within [PyClaw](http://www.clawpack.org/pyclaw/) to solve two standard test problems for one-dimensional compressible flow:\n",
     "\n",
     "  1. The Sod shocktube problem.  This is a Riemann problem, which we have considered previously.\n",
-    "  2. The Woodward-Colella blast wave problem.  This initially consists of two Riemann problems, with resulting shock waves of differing strengths.  These shock waves later interact with each other.\n",
+    "  2. The Woodward-Colella blast wave problem.  The initial data consists of two Riemann problems, with resulting shock waves of differing strengths.  These shock waves later interact with each other.\n",
     "  \n",
     "In this chapter, unlike previous chapters, we include extensive sections of code in the notebook.  This is meant to more easily allow the reader to use these as templates for setting up other problems.  For more information about the software and algorithms used here, see [this paper](https://peerj.com/articles/cs-68/) and references therein."
    ]
@@ -189,7 +189,7 @@
     "roe_st.run()\n",
     "hll_st = shocktube(q_l,q_r,N=50,riemann_solver='HLL')\n",
     "hll_st.run()\n",
-    "fine_st = shocktube(q_l,q_r,N=1000,riemann_solver='Roe')\n",
+    "fine_st = shocktube(q_l,q_r,N=2000,riemann_solver='Roe',solver_type='sharpclaw')\n",
     "fine_st.run();\n",
     "xc_st = roe_st.solution.state.grid.p_centers[0]\n",
     "xc_fine_st = fine_st.solution.state.grid.p_centers[0]\n",
@@ -218,7 +218,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we consider the Woodward-Colella blast wave problem."
+    "### Woodward-Colella blast wave"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we consider the Woodward-Colella blast wave problem, which is discussed for example in <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)</a></cite>.  [Describe the problem a bit more?]"
    ]
   },
   {
@@ -285,7 +292,7 @@
     "roe2.run()\n",
     "hll2 = shocktube(q_l,q_r,N=50,riemann_solver='HLL',solver_type='sharpclaw')\n",
     "hll2.run()\n",
-    "fine2 = shocktube(q_l,q_r,N=1000,riemann_solver='Roe',solver_type='sharpclaw')\n",
+    "fine2 = shocktube(q_l,q_r,N=2000,riemann_solver='Roe',solver_type='sharpclaw')\n",
     "fine2.run();\n",
     "xc = roe2.solution.state.grid.p_centers[0]\n",
     "xc_fine2 = fine2.solution.state.grid.p_centers[0]\n",

--- a/Euler_compare.ipynb
+++ b/Euler_compare.ipynb
@@ -174,7 +174,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We compare results obtained with these two solvers within a second-order Lax-Wendroff based scheme with limiters that is the basis of Clawpack.  We start with the Sod shocktube."
+    "We compare results obtained with these two solvers within a second-order Lax-Wendroff based scheme (with limiters to avoid nonphysical oscillations).  This method is the basis of Clawpack.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sod shock tube problem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first consider the classic shocktube problem proposed by Sod and already discussed in [Euler.ipynb](Euler.ipynb).  This is a particular Riemann problem in which the initial velocity is zero on both sides of a discontinuity in pressure and/or density of a gas, and so the exact Riemann solver for the Euler equations would provide the exact solution for all time, consisting of a right-going shock, a left-going rarefaction, and an intermediate contact discontinuity.\n",
+    "\n",
+    "In the numerical experiments done in this notebook, we use this initial data for a more general finite volume method that could be used to approximate the solution for any initial data.  In the first time step there is a single cell interface with nontrivial Riemann data, but as the solution evolves on the grid the Riemann problems that arise in subsequent time steps are very different from the single problem we started with.  Depending on the accuracy of the numerical method, the resolution of the grid, and the choice of approximate Riemann solver to use at each grid cell every time step, the numerical solution may deviate significantly from the exact solution to the original shocktube problem.  This makes a good initial test problem for numerical methods because the exact solution can be computed for comparison purposes, and because it clearly shows whether the method introduces oscillations around discontinuities and/or smears them out.  "
    ]
   },
   {


### PR DESCRIPTION
I think this is a useful notebook.

For the Sod problem it is stated that the "fine grid" solution can be viewed as the exact solution, but as computed (especially in the first example where the clawpack solver is used with only 1000 points) the contact discontinuity is quite smeared out, which could lead to confusion on the part of the reader.  I tried changing to sharpclaw with 2000 points and it looks a bit better, maybe go to an even finer grid?  Or hardwire the exact solution since we have it?

I added some comment about the fact that a single Riemann problem is solved numerically to perhaps avoid confusion with the exact Riemann problem.

The initial data used for the blast wave problem seems to be specified as
```
q_l = Euler.conservative_to_primitive(1.,0.,1.)
q_r = Euler.conservative_to_primitive(1./8,0.,1./10)
```
but then these values are ignored in the `blastwave` function invoked in
```
roe_bw = blastwave(q_l,q_r,riemann_solver='Roe')
```
since this problem has 3 initial states that are hardwired into the function definition.  Am I missing something?  Can we remove `q_l, q_r` from this example?

It would be good if the plots could be titled something like `Density at t = 0.038` so the reader knows which variable is being plotted, and for comparison with e.g. Figure 15.5 in FVMHP.  Maybe add a bit more discussion of the blast wave problem?

Would it be useful to also plot u and p for these examples?

Many of the examples in this notebook threw a warning such as,
```
/Users/rjl/clawpack_src/clawpack-rbook2/clawpack/riemann/euler_1D_py.py:298: RuntimeWarning: invalid value encountered in sqrt
  rhsqrtl = np.sqrt(q_l[0,...])
```