### PR TITLE
Cannot start a line with + sign in markdown

### DIFF
--- a/Acoustics.ipynb
+++ b/Acoustics.ipynb
@@ -97,8 +97,7 @@
     " \\left[ \\begin{array}{c}\n",
     "p \\\\\n",
     "u \n",
-    "\\end{array} \\right]_t\n",
-    "+  \\underbrace{\\left[ \\begin{array}{cc}\n",
+    "\\end{array} \\right]_t +  \\underbrace{\\left[ \\begin{array}{cc}\n",
     "0 & K_0 \\\\\n",
     "1/\\rho_0 & 0  \\\\\n",
     "\\end{array} \\right]}_{\\mathbf{A}}\n",
@@ -431,7 +430,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Equation (4) wasn't  rendering properly in the html version and I finally figure out it was because one line of the markdown cell started with a + sign, and the line was interpreted as a bullet point even though it was in the middle of a latex align environment.