### PR TITLE
Remove latex macro and add transonic rarefaction example in euler approx notebook.

### DIFF
--- a/Euler_approximate.ipynb
+++ b/Euler_approximate.ipynb
@@ -111,7 +111,7 @@
     "\n",
     "Solving the system of equations\n",
     "\\begin{align}\n",
-    "q_r - q_l & = \\sum_{p=1}^3 \\wave_p = \\sum_{p=1}^3 \\alpha_p r_p\n",
+    "q_r - q_l & = \\sum_{p=1}^3 {\\mathcal W}_p = \\sum_{p=1}^3 \\alpha_p r_p\n",
     "\\end{align}  \n",
     "for the wave strengths gives\n",
     "\\begin{align}\n",
@@ -381,7 +381,30 @@
    "metadata": {},
    "source": [
     "### Transonic rarefactions and an entropy fix\n",
-    "To be written."
+    "Here is an example of a Riemann problem whose solution includes a transonic 2-rarefaction:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "left_state  = State(Density = 1.0,\n",
+    "                    Velocity = -2.,\n",
+    "                    Pressure = 0.1)\n",
+    "right_state = State(Density = 1.,\n",
+    "                    Velocity = 0.,\n",
+    "                    Pressure = 1.)\n",
+    "\n",
+    "states = compare_solutions(left_state,right_state,solvers=['Exact','Roe'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that in the exact solution, the right edge of the rarefaction travels to the right.  In the Roe solution, all waves travel to the left.  As in the case of the shallow water equations, here too this behavior can lead to unphysical solutions when this approximate solver is used in a numerical discretization.  In order to correct this, we can split the single wave into two when a transonic rarefaction is present, in a way similar to what is done in the shallow water equations.  We do not go into details here."
    ]
   },
   {


### PR DESCRIPTION
I decided not to write a lengthy section on entropy fixes for Euler since it is so similar to SW where I did write a longer section.  Instead, I've just added an example of a solution that would need an entropy fix along with a brief discussion.