### PR TITLE
Dockerfile: customize nb_user and nb_uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,10 @@ ENV PATH ${VIRTUAL_ENV}/bin:${PATH}
 ENV SHELL /bin/bash
 
 # Set up user
-ENV NB_USER jovyan
-ENV NB_UID 1000
+ARG NB_USER=jovyan
+ARG NB_UID=1000
+ENV NB_UID ${NB_UID}
+ENV USER ${NB_USER}
 ENV HOME /home/${NB_USER}
 
 RUN adduser --disabled-password \
@@ -46,7 +48,7 @@ WORKDIR ${HOME}
 
 RUN mkdir -p ${VIRTUAL_ENV} && chown ${NB_USER}:${NB_USER} ${VIRTUAL_ENV}
 
-User jovyan
+User ${NB_USER}
 
 RUN virtualenv ${VIRTUAL_ENV}
 ENV PYTHONHOME ${VIRTUAL_ENV}


### PR DESCRIPTION
This is a small change to the dockerfile, such that it is possible to customize the username and uid (which I want to do). Without build vars, the result is the same (sets the previous hardcoded values as defaults). It also works on mybinder, as you can see here: https://mybinder.org/v2/gh/haraldschilly/riemann_book/master