### PR TITLE
fix figure sizes in Nonconvex_scalar.ipynb 

### DIFF
--- a/Nonconvex_scalar.ipynb
+++ b/Nonconvex_scalar.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The scalar nonlinear conservation law $q_t + f(q)_x = 0$ is said to be \"genuinely nonlinear\" over some range of states between $q_l$ and $q_r$ if $f''(q) \\neq 0$ for all $q$ between these values.  This is true in particular if $f(q)$ is any quadratic function, for example the flux function for Burgers' equation and the LWR traffic flow model are genuinely nonlinear for all $q$.  The reason this is important is that it means that the characteristic speed $f'(q)$ is either monotonically increasing or monotonically decreasing over the interval between $q_l$ and $q_r$.  As discussed already in chapters [Burgers.ipynb](Burgers.ipynb) and [Traffic_flow.ipynb](Traffic_flow.ipynb), if $f'(q)$ is increasing as $q$ varies from $q_l$ to $q_r$ then the initial discontinuity of a Riemann problem spreads out into a smooth single-valued rarefaction wave.  On the other hand if $f'(q)$ is decreasing then the discontinuity propagates as a single shock wave with speed given by the Rankine-Hugoniot condition.  Hence the Riemann solution for a genuinely nonlinear scalar equation always consists of either a single rarefaction wave or a single shock.\n",
+    "The scalar nonlinear conservation law $q_t + f(q)_x = 0$ is said to be \"genuinely nonlinear\" over some range of states between $q_l$ and $q_r$ if $f''(q) \\neq 0$ for all $q$ between these values.  This is true in particular if $f(q)$ is any quadratic function, for example the flux function for Burgers' equation and the LWR traffic flow model are genuinely nonlinear for all $q$.  The reason this is important is that it means that the characteristic speed $f'(q)$ is either monotonically increasing or monotonically decreasing over the interval between $q_l$ and $q_r$.  As discussed already in chapters [Burgers](Burgers.ipynb) and [Traffic_flow](Traffic_flow.ipynb), if $f'(q)$ is increasing as $q$ varies from $q_l$ to $q_r$ then the initial discontinuity of a Riemann problem spreads out into a smooth single-valued rarefaction wave.  On the other hand if $f'(q)$ is decreasing then the discontinuity propagates as a single shock wave with speed given by the Rankine-Hugoniot condition.  Hence the Riemann solution for a genuinely nonlinear scalar equation always consists of either a single rarefaction wave or a single shock.\n",
     "\n",
     "The solution can be much more complicated if $f''(q)$ vanishes somewhere between $q_l$ and $q_r$, since this means that the characteristic speed may not vary monotonically.  As we will illustrate below, for a scalar conservation law of this type the solution to the Riemann problem might consist of multiple shocks and rarefaction waves.  These waves all originate from $x=0$ and the Riemann solution is still a similarity solution $q(x,t) = Q(x/t)$ for some single-valued function $Q(\\xi)$, but determining the right set of waves is more challenging.  Below we present results computed using an elegant form of the solution to general scalar conservation laws due to Osher."
    ]
@@ -24,7 +24,7 @@
     "\n",
     "The opposite extreme of genuine nonlinearity is \"linear degeneracy\".  The scalar advection equation has $f(q) = aq$ with constant characteristic speed $f'(q)\\equiv a$ and so $f''(q) \\equiv 0$ for all values of $q$.  Since it is a linear equation, it naturally fails to be genuinely nonlinear over any range of $q$ values.\n",
     "\n",
-    "Recall that in the Riemann solution for the scalar advection equation (discussed in [Advection.ipynb](Advection.ipynb)) the characteristics are parallel to the propagating discontinuity in the $x$-$t$ plane.  They are neither impinging on the discontinuity (as in a shock wave, where the characteristic speed decreases from $q_l$ to $q_r$) nor are they spreading out (as they would in a rarefaction wave with $f'(q)$ increasing).  "
+    "Recall that in the Riemann solution for the scalar advection equation (discussed in [Advection](Advection.ipynb)) the characteristics are parallel to the propagating discontinuity in the $x$-$t$ plane.  They are neither impinging on the discontinuity (as in a shock wave, where the characteristic speed decreases from $q_l$ to $q_r$) nor are they spreading out (as they would in a rarefaction wave with $f'(q)$ increasing).  "
    ]
   },
   {
@@ -33,7 +33,7 @@
    "source": [
     "## Implications to systems of equations\n",
     "\n",
-    "For hyperoblic systems of $m$ equations, there are $m$ different characteristic fields. For classical nonlinear systems such as the shallow water equations or the Euler equations of gas dynamics, the Riemann solution generally consists of $m$ waves, each of which is either a discontinuity or a rarefaction wave.  The fact that there is only one wave in each family results from the fact that, for these systems, each characteristic speed either varies monotonically through the wave (if the field is genuinely nonlinear) or else is constant across the wave (if the field is linearly degenerate).  In the former case the wave is either a single shock or rarefaction wave, and in the latter case the wave is a \"contact discontinuity\", as discussed further in [Shallow_water_tracer](Shallow_water_tracer.ipynb) and [Euler.ipynb](Euler.ipynb).  As in the case of scalar advection, the characteristic speed is constant across a contact discontinuity ($f'(q) \\equiv 0$ between the left and right states). The definition of genuine nonlinearity and linear degeneracy for systems of equations is given in [Shallow_water_tracer](Shallow_water_tracer.ipynb).\n",
+    "For hyperoblic systems of $m$ equations, there are $m$ different characteristic fields. For classical nonlinear systems such as the shallow water equations or the Euler equations of gas dynamics, the Riemann solution generally consists of $m$ waves, each of which is either a discontinuity or a rarefaction wave.  The fact that there is only one wave in each family results from the fact that, for these systems, each characteristic speed either varies monotonically through the wave (if the field is genuinely nonlinear) or else is constant across the wave (if the field is linearly degenerate).  In the former case the wave is either a single shock or rarefaction wave, and in the latter case the wave is a \"contact discontinuity\", as discussed further in [Shallow_water_tracer](Shallow_water_tracer.ipynb) and [Euler](Euler.ipynb).  As in the case of scalar advection, the characteristic speed is constant across a contact discontinuity ($f'(q) \\equiv 0$ between the left and right states). The definition of genuine nonlinearity and linear degeneracy for systems of equations is given in [Shallow_water_tracer](Shallow_water_tracer.ipynb).\n",
     "\n",
     "The nonconvex equations studied in this chapter illustrate that even for a scalar problem the Riemann solution becomes much more complicated if the problem fails to be genuinely nonlinear or linearly degenerate.  *Systems* of equations that lack the corresponding properties are more difficult still and are beyond the scope of this book, although they do arise in some important applcations, such as magnetohydrodynamics (MHD)."
    ]
@@ -61,7 +61,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline"
@@ -99,7 +103,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that in [exact_solvers/nonconvex.py](exact_solvers/nonconvex.py) we use the function `osher_solution` to define a function `nonconvex_solutions` that evaluates this solution at a set of `xi = x/t` values.  It also computes the possibly multi-valued solution that would be obtained by tracing characteristics, for plotting purposes.  In [exact_solvers/nonconvex_demos.py](exact_solvers/nonconvex_demos.py), an additional function `make_plot_function` returns a plotting function for use in interactive widgets below.  "
+    "In this code, note that we use the function `osher_solution` to define a function `nonconvex_solutions` that evaluates this solution at a set of `xi = x/t` values.  It also computes the possibly multi-valued solution that would be obtained by tracing characteristics, for plotting purposes. "
    ]
   },
   {
@@ -108,7 +112,7 @@
    "source": [
     "## Traffic flow\n",
     "\n",
-    "First we recall that the Riemann solution for a convex flux consists of a single shock or rarefaction wave.  For example, consider the flux function $f(q) = q(1-q)$ from traffic flow (with $q$ now representing the density $\\rho$ that was used in [Traffic_flow.ipynb](Traffic_flow.ipynb))."
+    "First we recall that the Riemann solution for a convex flux consists of a single shock or rarefaction wave.  For example, consider the flux function $f(q) = q(1-q)$ from traffic flow (with $q$ now representing the density $\\rho$ that was used in [Traffic_flow](Traffic_flow.ipynb))."
    ]
   },
   {
@@ -137,7 +141,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "f = lambda q: q*(1-q)\n",
@@ -184,11 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nonconvex_demos.plot_flux(f_buckley_leverett, q_left, q_right)"
@@ -393,13 +395,6 @@
    "source": [
     "Experiment with this and other flux functions in this notebook!  But please note that the plotting functions, as written, may break down if you try an example with too many oscillations in the flux."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/exact_solvers/nonconvex_demos.py
+++ b/exact_solvers/nonconvex_demos.py
@@ -6,7 +6,7 @@ from . import nonconvex
 
 from utils import riemann_tools
 
-#figsize =(12,4)
+figsize =(8,4)
 
 def plot_waves(f,q_left, q_right, xi_left, xi_right, n=1000, axes=None, t=0.2):
     qtilde = nonconvex.osher_solution(f, q_left, q_right, 1000)
@@ -55,7 +55,7 @@ def make_plot_function(f, q_left, q_right, xi_left, xi_right):
         converting to html files.
         """
         if fig==0: 
-            plt.figure(figsize=(8,4));
+            plt.figure(figsize=figsize);
             
         # plot solution q(x,t):
         plt.subplot(1,3,1)
@@ -93,7 +93,7 @@ def make_plot_function(f, q_left, q_right, xi_left, xi_right):
 def demo1():
     f = lambda q: q*(1-q)
 
-    #plt.figure(figsize=(12,5))
+    plt.figure(figsize=figsize)
     plt.subplot(121)
 
     q_left = 0.6;  q_right = 0.1
@@ -120,7 +120,7 @@ def plot_flux(f, q_left, q_right, plot_zero=True):
     dfdq = np.diff(fvals) / (qvals[1]-qvals[0])  # approximate df/dq
     qmid = 0.5*(qvals[:-1] + qvals[1:])   # midpoints for plotting dfdq
 
-    #plt.figure(figsize=(12,4))
+    plt.figure(figsize=(8,3))  # figures look better this way
     plt.subplot(131)
     plt.plot(qvals,fvals)
     plt.xlabel('q')
@@ -156,7 +156,7 @@ def make_plot_function_qsliders(f):
         converting to html files.
         """
         if fig==0: 
-            plt.figure(figsize=(8,4))
+            plt.figure(figsize=figsize)
 
         xi_left = -3.
         xi_right = 3.


### PR DESCRIPTION
And clean up text and cross references a bit.  

In particular I changed references such as `[Burgers.ipynb](Burgers.ipynb)` to `[Burgers](Burgers.ipynb)` to be consistent with what we do elsewhere and I think it looks a bit nicer in the notebooks.

There was also a hidden cell that should not have been.