### PR TITLE
Burgers/traffic swap

### DIFF
--- a/Burgers.ipynb
+++ b/Burgers.ipynb
@@ -42,7 +42,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this chapter, we study another scalar nonlinear conservation law: Burgers' equation.  Burgers' equation models momentum transport in a fluid of uniform density and pressure, and it is the simplest equation that captures some key features of gas dynamics.\n",
+    "In this chapter, we study a simple scalar nonlinear conservation law: Burgers' equation.  Burgers' equation models momentum transport in a fluid of uniform density and pressure, and it is the simplest equation that captures some key features of gas dynamics or shallow water flow.\n",
     "\n",
     "To examine the Python code for this chapter, see:\n",
     "\n",
@@ -54,7 +54,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Burgers' equation has been used extensively for developing both theory and numerical methods, and it will allow us to further explore the Riemann problem for nonlinear conservation laws. The equation is given by\n",
+    "Burgers' equation has been used extensively for developing both theory and numerical methods, and it will allow us to further explore the Riemann problem for nonlinear conservation laws. The Burgers' equation is given by\n",
     "\\begin{align}\n",
     "q_t + \\left(\\frac{1}{2}q^2\\right)_x = 0.\n",
     "\\label{burgers0}\n",
@@ -89,7 +89,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that at first $q$ remains single-valued for every $x$. However, after some time the crest of the wave overtakes the leading edge. After this time, we obtain a triple-valued solution for certain values of $x$, which is unphysical since momentum is single-valued. The first time this overtaking happens is referred to as the *breaking time* -- a reference to waves breaking on the beach. It is also the point where the conservation law, in its differential form, breaks down and where the characteristics cross each other for the first time.  As we learned in [Traffic_flow.ipynb](Traffic_flow.ipynb), when characteristics cross, a shock wave forms. Mathematically, imposing a shock will avoid the problem of the solution being multivalued.  Where should the shock be located?\n",
+    "Notice that at first $q$ remains single-valued for every $x$. However, after some time the crest of the wave overtakes the leading edge. After this time, we obtain a triple-valued solution for certain values of $x$, which is unphysical since momentum is single-valued. The first time this overtaking happens is referred to as the *breaking time* -- a reference to waves breaking on the beach. It is also the point where the conservation law, in its differential form, breaks down and where the characteristics cross each other for the first time.   When characteristics cross, a shock wave forms. Mathematically, imposing a shock will avoid the problem of the solution being multivalued.  Where should the shock be located?\n",
     "\n",
     "If we replace part of the multivalued solution interval with a shock, some mass will be removed (area $A_1$ in the figure below) and some mass will be added (area $A_2$ in the figure below). In the live notebook, the figure below shows possible locations for the shock at a given time; in order to maintain conservation of the integral of $q$, the shock must be placed so that these two areas are equal."
    ]
@@ -109,13 +109,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This geometric reasoning provides a nice intuition for the shock location, but is cumbersome in practice.  To determine the path of the shock we can again use the Rankine-Hugoniot jump condition, derived in [Traffic_flow.ipynb](Traffic_flow.ipynb).  Since the flux for Burgers' equation is $f(q) = q^2/2$, we have  \n",
+    "This geometric reasoning provides a nice intuition for the shock location, but is cumbersome in practice.  To determine the path of the shock we can use the *Rankine-Hugoniot jump condition,* which we will derive in [Traffic_flow](Traffic_flow.ipynb), and requires that the the jump in flux across a propagating shock must be related to the jump in $q$ by\n",
+    "\n",
+    "$$\n",
+    "s(q_r-q_l)  = f(q_r) - f(q_l),\n",
+    "$$\n",
+    "\n",
+    "at each instant in time, where $s$ is the shock speed at this time. \n",
+    "\n",
+    "Since the flux for Burgers' equation is $f(q) = q^2/2$, this gives\n",
     "\\begin{align*}\n",
-    "s(q_r-q_l) & = f(q_r) - f(q_l)\\\\\n",
-    "           & = \\frac{1}{2} (q_r^2 - q_l^2) \\\\\n",
+    "s(q_r-q_l) & = \\frac{1}{2} (q_r^2 - q_l^2) \\\\\n",
     "\\Rightarrow \\ \\ \\ \\ s &= \\frac{1}{2}(q_l + q_r).\n",
     "\\end{align*}  \n",
-    "Here $q_l, q_r$ denote the solution values just to the left and right of the shock.  In general (as in the image above) these states will not be constant and the speed of a shock will change in time."
+    "In general (as in the image above) the states $q_l$ and $q_r$ just to the left and right of the shock will not be constant and the speed of a shock will change in time."
    ]
   },
   {
@@ -123,7 +130,7 @@
    "metadata": {},
    "source": [
     "### Shock solution\n",
-    "For Burgers' equation, as for the traffic model (or any scalar hyperbolic conservation law with a convex flux function), the solution of the Riemann problem will always consist of one wave, which may be either a shock or a rarefaction.  The analysis above already yields the solution to the Riemann problem in the case that the resulting wave is a shock.  The entropy condition, as we will explain below, indicates that a shock will form when $f'(q_l) > f'(q_r)$; i.e. when $q_l>q_r$.  In this case, the solution is \n",
+    "For Burgers' equation, (or any scalar hyperbolic conservation law with a convex flux function, such as the traffic flow problem considered in [Traffic_flow](Traffic_flow.ipynb)), the solution of the Riemann problem will always consist of a single wave, which may be either a shock or a rarefaction.  The analysis above already yields the solution to the Riemann problem in the case that the resulting wave is a shock.  The entropy condition, as we will explain below, indicates that a shock will form when $f'(q_l) > f'(q_r)$; i.e. when $q_l>q_r$.  In this case, the solution is \n",
     "\n",
     "\\begin{align*}\n",
     "q(x,t) = \n",
@@ -181,7 +188,7 @@
     "\\end{cases}\n",
     "\\end{align*}\n",
     "\n",
-    "As we will see in the next chapter, the rarefaction solution is always a self-similar solution. This means that it can be expressed as a function of the ratio between position and time $q(x,t) = \\tilde{q}(x/t)$, so it remains the same when rescaling both $x$ and $t$ by the same factor. This is a consequence of $q$ being the same along the characteristic in the rarefaction fan. In the Burgers' equation, the form of the rarefaction is particularly simple since the advection speed is simply $q$."
+    "As we will see in [Traffic_flow](Traffic_flow.ipynb), the rarefaction solution is always a self-similar solution. This means that it can be expressed as a function of the ratio between position and time $q(x,t) = \\tilde{q}(x/t)$, so it remains the same when rescaling both $x$ and $t$ by the same factor. This is a consequence of $q$ being the same along the characteristic in the rarefaction fan. In the Burgers' equation, the form of the rarefaction is particularly simple since the advection speed is simply $q$."
    ]
   },
   {
@@ -216,7 +223,7 @@
    "metadata": {},
    "source": [
     "As we mentioned before, the differential form of the equation breaks down in the presence of shocks/discontinuities. However, the integral form of the conservation law remains valid. We will derive a specific form of the integral conservation law that is particularly useful to prove mathematical results.\n",
-    "We first integrate the general conservation law $q_t+f(q)_x=0$ from from $x=x_1$ to $x=x_2$ and $t=t_1$ to $t=t_2$\n",
+    "We first integrate the general conservation law $q_t+f(q)_x=0$ from $x=x_1$ to $x=x_2$ and $t=t_1$ to $t=t_2$\n",
     "\n",
     "\\begin{align}\n",
     "\\int_{t_1}^{t_2}\\int_{x_1}^{x_2} [q_t+f(q)_x] dx dt = 0,\n",
@@ -233,9 +240,9 @@
     "\\begin{align*}\n",
     "\\int_{0}^{\\infty}\\int_{-\\infty}^{\\infty} [q\\phi_t+f(q)\\phi_x] dx dt = -\\int_{-\\infty}^{\\infty}q(x,0)\\phi(x,0)dx,\n",
     "\\end{align*}\n",
-    "where now the derivatives are on $\\phi(x,t)$ and not on $q$ or $f(q)$, so the equation still makes sense for discontinuous $q$. The function $q(x,t)$ is a weak solution of the conservation law if this equation holds for all functions $\\phi(x,t)$ that are continuously differentiable and with compact support (bump functions). Note this rules out the original interval chosen in Eq. \\ref{eq:Burgersintclaw} since its $\\phi$ would not be smooth. However, we can approximate this function arbitrarily well by a smooth function. Note any weak solution is a solution of any form of the integral conservation law and vice versa.\n",
+    "where now the derivatives are on $\\phi(x,t)$ and not on $q$ or $f(q)$, so the equation still makes sense for discontinuous $q$. The function $q(x,t)$ is called a *weak solution* of the conservation law if this equation holds for all functions $\\phi(x,t)$ that are continuously differentiable and with compact support (bump functions). Note this rules out the original interval chosen in Eq. \\ref{eq:Burgersintclaw} since its $\\phi$ would not be smooth. However, we can approximate this function arbitrarily well by a smooth function. Note any weak solution is a solution of any form of the integral conservation law and vice versa.\n",
     "\n",
-    "Weak solutions are thus allowed to include discontinuities.  The shock solution presented above, for instance, is a weak solution of the Burgers' equation.  After characteristics cross, we cannot have strong solutions of the conservation law, and we must resort to weak solutions. However, one given problem may have multiple weak solutions."
+    "Weak solutions are thus allowed to include discontinuities.  The shock solution presented above, for instance, is a weak solution of the Burgers' equation.  After characteristics cross, we cannot have strong solutions of the conservation law, and we must resort to weak solutions. However, a potential problem with the notion of weak solutions is that in some cases the weak solution is not unique and it is possible to determine more than one function that satisifes the condition above. This generally happens when discontinuous initial data should lead to a rarefaction wave solution but there is also a discontinous weak solution that is allowed mathematically but is not physically correct."
    ]
   },
   {
@@ -282,17 +289,21 @@
    "source": [
     "### The entropy condition\n",
     "\n",
-    "In the traffic flow chapter, we introduced the entropy condition which determines the correct physical solution among all the possible weak solutions. In the context of the Riemann problem, the entropy condition allows us to determine if the physical solution should involve a shock or a rarefaction. In the case of scalar conservation laws, the entropy condition is quite simple and can be formulated in terms of the flux function of the conservation law as follows: the solution of a scalar Riemann problem will consist of a shock only if\n",
+    "Any condition that allows us to determine whether a weak solution to a conservation law is actually physically correct is called an *admissibility condition* or more often an *entropy condition*.  This name comes from gas dynamics, where the physical entropy must increase in the gas passing through a shock, according to the second law of thermodynamics.  A discontinuity that violates this is non-physical. A mathematical version of an \"entropy function\" can be defined for other conservation laws.  More discussion of this and several other formulations with more detailed explanations are available in the literature, e.g., <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque, 2002)</a></cite>.\n",
+    "\n",
+    "In the context of the Riemann problem, the entropy condition allows us to determine if the physical solution should involve a shock or a rarefaction. In the case of scalar conservation laws, the entropy condition is quite simple and can be formulated in terms of the flux function of the conservation law as follows: the solution of a scalar Riemann problem will consist of a shock only if\n",
     "\n",
     "$$\n",
     "f'(q_l) > f'(q_r).\n",
     "$$\n",
+    "\n",
     "In other words, the solution is a shock only if the characteristics are going into the shock as time progresses. If the characteristics are spreading out/going out of the shock as in the last example, one would naturally expect a rarefaction to be the correct solution. In the case of Burgers' equation, the flux function is $f(q)=q^2/2$, so the correct solution is a shock only if\n",
     "\n",
     "$$\n",
     "q_l > q_r,\n",
     "$$\n",
-    "which can be clearly observed in the interactive solution below. The name, \"entropy condition\", comes from gas dynamics, where the physical entropy must increase in the gas passing through a shock, according to the second law of thermodynamics.  A discontinuity that violates this is non-physical. A mathematical version of an \"entropy function\" can be defined for other conservation laws.  More discussion of this and several other formulations and more detailed explanations available in the literature <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque, 2002)</a></cite>. In later chapters, we will see how this condition generalizes to systems of conservation laws."
+    "\n",
+    "which can be clearly observed in the interactive solution below.   In later chapters, we will see how this condition generalizes to systems of conservation laws."
    ]
   },
   {
@@ -303,9 +314,9 @@
     "\n",
     "The flux $f(q) = q^2/2$ for Burgers' equation is a convex function, since $f''(q) = 1 > 0$ for all values of $q$. This means that as $q$ varies between $q_l$ and $q_r$ the the characteristic speed $f'(q) = q$ is either monotonically increasing (if $q_l < q_r$) or monotomically decreasing (if $q_l > q_r$).  Because of this the solution is always either a single rarefaction wave or a single shock wave.\n",
     "\n",
-    "The flux $f(\\rho) = \\rho(1-\\rho)$ from the LWR traffic flow model also has the property that $f'(\\rho)$ varies monotonically with $\\rho$ (in the context of hyperbolic PDEs, a flux function is referred to as *convex* if either $f''(q)\\ge0$ for all $q$ or $f''(q)\\le 0$ for all $q$).  Since $f''$ is always negative, as we saw in [Traffic_flow.ipynb](Traffic_flow.ipynb), the correct Riemann solution is a shock if $\\rho_l < \\rho_r$, or a rarefaction wave if $\\rho_l > \\rho_r$.\n",
+    "The flux $f(\\rho) = \\rho(1-\\rho)$ simple traffic flow model considered in [Traffic_flow](Traffic_flow.ipynb) also has the property that $f'(\\rho)$ varies monotonically with $\\rho$ (in the context of hyperbolic PDEs, a flux function is referred to as *convex* if either $f''(q)\\ge0$ for all $q$ or $f''(q)\\le 0$ for all $q$).  Since $f''$ is always negativefor the traffic flow model, the correct Riemann solution is a shock if $\\rho_l < \\rho_r$, or a rarefaction wave if $\\rho_l > \\rho_r$.\n",
     "\n",
-    "The solution to the Riemann problem can be much more complicated if $f'(q)$ is not monotonically varying between $q_l$ and $q_r$, i.e. if $f''(q)$ changes sign.  In this case the Riemann solution can consist of multiple shock and rarefaction waves.  The nonconvex case is explored further in [Nonconvex_scalar.ipynb](Nonconvex_scalar.ipynb)."
+    "The solution to the Riemann problem can be much more complicated if $f'(q)$ is not monotonically varying between $q_l$ and $q_r$, i.e. if $f''(q)$ changes sign.  In this case the Riemann solution can consist of multiple shock and rarefaction waves.  The nonconvex case is explored further in [Nonconvex_scalar](Nonconvex_scalar.ipynb)."
    ]
   },
   {
@@ -347,6 +358,15 @@
    "outputs": [],
    "source": [
     "burgers_demos.bump_animation(numframes = 50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "burgers_demos.bump_animation??"
    ]
   },
   {

--- a/Burgers.ipynb
+++ b/Burgers.ipynb
@@ -63,7 +63,9 @@
     "\\begin{align*}\n",
     "q_t + qq_x = 0.\n",
     "\\end{align*}  \n",
-    "This equation looks very similar to the advection equation, with the difference that the advection speed at each point is given by the solution $q$.  The nonlinearity in the Burgers flux term is essentially the same as in the momentum conservation equation in fluid dynamics, so studying its dynamics provides a guideline to understand the more complex nonlinear systems arising in the study of shallow water or Euler equations, as we pursue further in [Shallow_water](Shallow_water.ipynb) and [Euler](Euler.ipynb)."
+    "This equation looks very similar to the advection equation, with the difference that the advection speed at each point is given by the solution $q$.  The nonlinearity in the Burgers flux term is essentially the same as in the momentum conservation equation in fluid dynamics, so studying its dynamics provides a guideline to understand the more complex nonlinear systems arising in the study of shallow water or Euler equations, as we pursue further in [Shallow_water](Shallow_water.ipynb) and [Euler](Euler.ipynb).\n",
+    "\n",
+    "In [Traffic_flow](Traffic_flow.ipynb) we consider another scalar nonlinear conservation law that has a similar structure to Burgers' equation and a nice physical interpretation."
    ]
   },
   {

--- a/Burgers.ipynb
+++ b/Burgers.ipynb
@@ -112,11 +112,9 @@
    "metadata": {},
    "source": [
     "This geometric reasoning provides a nice intuition for the shock location, but is cumbersome in practice.  To determine the path of the shock we can use the *Rankine-Hugoniot jump condition,* which we will derive in [Traffic_flow](Traffic_flow.ipynb), and requires that the jump in flux across a propagating shock must be related to the jump in $q$ by\n",
-    "\n",
     "$$\n",
     "s(q_r-q_l)  = f(q_r) - f(q_l),\n",
     "$$\n",
-    "\n",
     "at each instant in time, where $s$ is the shock speed at this time. \n",
     "\n",
     "Since the flux for Burgers' equation is $f(q) = q^2/2$, this gives\n",
@@ -133,7 +131,6 @@
    "source": [
     "### Shock solution\n",
     "For Burgers' equation, (or any scalar hyperbolic conservation law with a convex flux function, such as the traffic flow problem considered in [Traffic_flow](Traffic_flow.ipynb)), the solution of the Riemann problem will always consist of a single wave, which may be either a shock or a rarefaction.  The analysis above already yields the solution to the Riemann problem in the case that the resulting wave is a shock.  The entropy condition, as we will explain below, indicates that a shock will form when $f'(q_l) > f'(q_r)$; i.e. when $q_l>q_r$.  In this case, the solution is \n",
-    "\n",
     "\\begin{align*}\n",
     "q(x,t) = \n",
     "\\begin{cases}\n",
@@ -226,19 +223,16 @@
    "source": [
     "As we mentioned before, the differential form of the equation breaks down in the presence of shocks/discontinuities. However, the integral form of the conservation law remains valid. We will derive a specific form of the integral conservation law that is particularly useful to prove mathematical results.\n",
     "We first integrate the general conservation law $q_t+f(q)_x=0$ from $x=x_1$ to $x=x_2$ and $t=t_1$ to $t=t_2$\n",
-    "\n",
     "\\begin{align}\n",
     "\\int_{t_1}^{t_2}\\int_{x_1}^{x_2} [q_t+f(q)_x] dx dt = 0,\n",
     "\\label{eq:Burgersintclaw}\n",
     "\\end{align}\n",
     "This integral can be rewritten in terms of an indicator function $\\phi(x,t)$ with compact support in $[x_1,x_2]\\times[t_1,t_2]$ (defined to be 1 in this region, zero elsewhere):\n",
-    "\n",
     "\\begin{align*}\n",
     "\\int_{0}^{\\infty}\\int_{-\\infty}^{\\infty} [q_t+f(q)_x]\\phi(x,t) dx dt = 0.\n",
     "\\end{align*}\n",
     "\n",
     "We can generalize this result by replacing $\\phi(x,t)$ by a smooth function with compact support on some region of the $x-t$ plane. In this case, integrating by parts yield\n",
-    "\n",
     "\\begin{align*}\n",
     "\\int_{0}^{\\infty}\\int_{-\\infty}^{\\infty} [q\\phi_t+f(q)\\phi_x] dx dt = -\\int_{-\\infty}^{\\infty}q(x,0)\\phi(x,0)dx,\n",
     "\\end{align*}\n",
@@ -254,7 +248,6 @@
     "### An unphysical weak solution\n",
     "\n",
     "We previously mentioned that for Burgers' equation, when $q_l<q_r$, we expect a rarefaction to be the correct solution. This is because if we smeared out the initial data just slightly then there would be smoothly varying characteristics emerging from each point $x$ and these characteristics would spread out.  However, for exactly discontinuous initial data, we could also assume the solution consists of a propagating discontinuity and then use the equation in its conservative form to derive the Rankine-Hugoniot conditions, as done in previous chapters and in <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque, 2002)</a></cite>. This is mathematically correct and one obtains the same relation for the shock speed as before, $s = (q_l + q_r)/2$ , so the solution is simply\n",
-    "\n",
     "\\begin{align*}\n",
     "q(x,t) = \n",
     "\\begin{cases}\n",
@@ -262,7 +255,6 @@
     "q_r \\quad \\text{if} \\ \\ x/t>s.\n",
     "\\end{cases}\n",
     "\\end{align*}\n",
-    "\n",
     "This unphysical solution is also referred to as an expansion shock, and it is also a weak solution to Burgers' equation. In the next figure, we plot this weak solution."
    ]
   },
@@ -294,17 +286,13 @@
     "Any condition that allows us to determine whether a weak solution to a conservation law is actually physically correct is called an *admissibility condition* or more often an *entropy condition*.  This name comes from gas dynamics, where the physical entropy must increase in the gas passing through a shock, according to the second law of thermodynamics.  A discontinuity that violates this is non-physical. A mathematical version of an \"entropy function\" can be defined for other conservation laws.  More discussion of this and several other formulations with more detailed explanations are available in the literature, e.g., <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque, 2002)</a></cite>.\n",
     "\n",
     "In the context of the Riemann problem, the entropy condition allows us to determine if the physical solution should involve a shock or a rarefaction. In the case of scalar conservation laws, the entropy condition is quite simple and can be formulated in terms of the flux function of the conservation law as follows: the solution of a scalar Riemann problem will consist of a shock only if\n",
-    "\n",
     "$$\n",
     "f'(q_l) > f'(q_r).\n",
     "$$\n",
-    "\n",
     "In other words, the solution is a shock only if the characteristics are going into the shock as time progresses. If the characteristics are spreading out/going out of the shock as in the last example, one would naturally expect a rarefaction to be the correct solution. In the case of Burgers' equation, the flux function is $f(q)=q^2/2$, so the correct solution is a shock only if\n",
-    "\n",
     "$$\n",
     "q_l > q_r,\n",
     "$$\n",
-    "\n",
     "which can be clearly observed in the interactive solution below.   In later chapters, we will see how this condition generalizes to systems of conservation laws."
    ]
   },
@@ -326,14 +314,7 @@
    "metadata": {},
    "source": [
     "## Interactive solution and examples\n",
-    "We can now explore a few more examples that are representative of phenomena we will observe in more complicated systems. Before exploring more complicated examples, we first show a full interactive solution for the Riemann problem for Burgers' equation. The values of the initial conditions and the time can be modified to observe their effect on the characteristic structure and the solution. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Why doesn't this example have the desired widgets?**"
+    "The live notebook next shows a full interactive solution for the Riemann problem for Burgers' equation. The values of the initial conditions and the time can be modified to observe their effect on the characteristic structure and the solution. "
    ]
   },
   {
@@ -349,8 +330,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Animations of more complex solutions\n",
+    "We can now explore a few more examples that are representative of phenomena we will observe in more complicated systems, with more interesting initial data that the single jump discontinuity of a Riemann problem.  For the animations shown below, the solution is computed numerically using [PyClaw](http://www.clawpack.org/pyclaw/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Example 1: Bump initial condition\n",
-    "The animation below, or on [this webpage](http://www.clawpack.org/riemann_book/html/burgers_animation0.html),  shows the solution of Burgers' equation for an initial Gaussian hump.  The solution is computed numerically using [PyClaw](http://www.clawpack.org/pyclaw/)."
+    "The animation below, or on [this webpage](http://www.clawpack.org/riemann_book/html/burgers_animation0.html),  shows the solution of Burgers' equation for an initial Gaussian hump."
    ]
   },
   {

--- a/Burgers.ipynb
+++ b/Burgers.ipynb
@@ -63,7 +63,7 @@
     "\\begin{align*}\n",
     "q_t + qq_x = 0.\n",
     "\\end{align*}  \n",
-    "This equation looks very similar to the advection equation, with the difference that the advection speed at each point is given by the solution $q$.  The nonlinearity in the Burgers flux term is essentially the same as in the momentum conservation equation in fluid dynamics, so studying its dynamics provides a guideline to understand more complex fluid dynamics, as we will do in [Euler.ipynb](Euler.ipynb)."
+    "This equation looks very similar to the advection equation, with the difference that the advection speed at each point is given by the solution $q$.  The nonlinearity in the Burgers flux term is essentially the same as in the momentum conservation equation in fluid dynamics, so studying its dynamics provides a guideline to understand the more complex nonlinear systems arising in the study of shallow water or Euler equations, as we pursue further in [Shallow_water](Shallow_water.ipynb) and [Euler](Euler.ipynb)."
    ]
   },
   {
@@ -109,7 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This geometric reasoning provides a nice intuition for the shock location, but is cumbersome in practice.  To determine the path of the shock we can use the *Rankine-Hugoniot jump condition,* which we will derive in [Traffic_flow](Traffic_flow.ipynb), and requires that the the jump in flux across a propagating shock must be related to the jump in $q$ by\n",
+    "This geometric reasoning provides a nice intuition for the shock location, but is cumbersome in practice.  To determine the path of the shock we can use the *Rankine-Hugoniot jump condition,* which we will derive in [Traffic_flow](Traffic_flow.ipynb), and requires that the jump in flux across a propagating shock must be related to the jump in $q$ by\n",
     "\n",
     "$$\n",
     "s(q_r-q_l)  = f(q_r) - f(q_l),\n",
@@ -358,15 +358,6 @@
    "outputs": [],
    "source": [
     "burgers_demos.bump_animation(numframes = 50)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "burgers_demos.bump_animation??"
    ]
   },
   {

--- a/Index.ipynb
+++ b/Index.ipynb
@@ -23,8 +23,8 @@
     "  1. [Introduction](Introduction.ipynb). Introduces basic ideas with some sample solutions.\n",
     "  1. [Advection](Advection.ipynb) The scalar advection equation is the simplest hyperbolic problem.\n",
     "  2. [Acoustics](Acoustics.ipynb) This linear system of two equations illustrates how eigenstructure is used.\n",
-    "  3. [Traffic flow](Traffic_flow.ipynb) A nonlinear scalar problem with a nice physical interpretation.\n",
-    "  4. [Burgers' equation](Burgers.ipynb) The classic nonlinear scalar problem with a convex flux.\n",
+    "  3. [Burgers' equation](Burgers.ipynb) The classic nonlinear scalar problem with a convex flux.\n",
+    "  4. [Traffic flow](Traffic_flow.ipynb) A nonlinear scalar problem with a nice physical interpretation.\n",
     "  5. [Nonconvex_scalar](Nonconvex_scalar.ipynb) More interesting Riemann solutions arise when the flux is not convex.\n",
     "  6. [Shallow water waves](Shallow_water.ipynb) A classic nonlinear system of two equations\n",
     "  7. [Shallow water with a tracer](Shallow_tracer.ipynb) Adding a passively advected tracer and a linearly degenerate field.\n",
@@ -66,13 +66,6 @@
     "  2. [Elasticity](http://nbviewer.jupyter.org/github/maojrs/ipynotebooks/blob/master/elasticity_riemann.ipynb) *[To be improved and incorporated into this project]*\n",
     "  3. [The Kitchen Sink: shallow water in cylindrical coordinates](Kitchen_sink_problem.ipynb)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Traffic_flow.ipynb
+++ b/Traffic_flow.ipynb
@@ -64,15 +64,11 @@
    "source": [
     "## The LWR model\n",
     "Recall the continuity equation for any density that is advected with a flow: \n",
-    "\n",
     "$$\\rho_t + (u\\rho)_x = 0.$$  \n",
-    "\n",
     "In this chapter, $\\rho$ represents the density of cars on a road, traveling with velocity $u$.  Note that we're not keeping track of the individual cars, but just of the average number of cars per unit length of road.  Thus $\\rho=0$ represents an empty stretch of road, and we can choose the units so that $\\rho=1$ represents bumper-to-bumper traffic.\n",
     "\n",
     "We'll also choose units so that the speed limit is $u_\\text{max}=1$, and assume that drivers never go faster than this (yeah, right!).  If we assume that drivers always travel at a single uniform velocity, we obtain once again the advection equation that we studied in [Advection](Advection.ipynb).  But we all know that's not accurate in practice -- cars go faster in light traffic and slower when there is congestion.  The simplest way to incorporate this effect is to make the velocity a linearly decreasing function of the density:\n",
-    "\n",
     "$$u(\\rho) = 1 - \\rho.$$\n",
-    "\n",
     "Notice that $u$ goes to zero as $\\rho$ approaches the maximum density of 1, while $u$ goes to the maximum value of 1 as traffic density goes to zero.  Obviously, both $\\rho$ and $u$ should always stay in the interval $[0,1]$."
    ]
   },
@@ -88,9 +84,7 @@
    "metadata": {},
    "source": [
     "Combining the two equations above, our conservation law says\n",
-    "\n",
     "$$\\rho_t + (\\rho (1-\\rho))_x = 0.$$\n",
-    "\n",
     "The function $f(\\rho) = \\rho(1-\\rho)$ is the flux, or the rate of flow of cars.  Notice how the flux is zero when there are no cars and also when the road is completely full.  The maximum flow of traffic actually occurs when the road is half full, as the plot below shows."
    ]
   },
@@ -109,13 +103,9 @@
    "metadata": {},
    "source": [
     "This equation is fundamentally different from the advection equation because the flux is **nonlinear**.  This fact will have dramatic consequences for both the behavior of solutions and our numerical methods.  But we can superficially make this equation look like the advection equation by using the chain rule to write it in quasilinear form:  \n",
-    "\n",
     "$$f(\\rho)_x = f'(\\rho) \\rho_x = (1-2\\rho)\\rho_x.$$  \n",
-    "\n",
     "Then we have  \n",
-    "\n",
     "$$\\rho_t + (1-2\\rho)\\rho_x = 0.$$  \n",
-    "\n",
     "This is like the advection equation, but with a velocity $1-2\\rho$ that depends on the density of cars.  The value $f'(\\rho)=1-2\\rho$ is referred to as the *characteristic speed*.  This characteristic speed is not the speed at which cars move (notice that it can even be negative, whereas cars only drive to the right in our model)  Rather, it is the speed at which *information* is transmitted along the road."
    ]
   },
@@ -126,12 +116,10 @@
     "## Example: Traffic jam\n",
     "\n",
     "What does our model predict when traffic approaches a totally congested ($\\rho=1$) area?  This might be due to construction, an accident or a red light somewhere to the right; upstream of the obstruction, cars will be bumper-to-bumper, so we set $\\rho=1$ for $x>0$ (supposing that traffic has backed up to that point).  For $x<0$ we'll assume a lower density $\\rho_l<1$.  This is another example of a Riemann problem: two constant states separated by a discontinuity.  We have  \n",
-    "\n",
     "$$\n",
     "\\rho(x,t=0) = \\begin{cases} \\rho_l & x<0 \\\\\n",
     "                            1 & x>0. \\end{cases}\n",
     "$$  \n",
-    "\n",
     "What will happen as time goes forward?  Intuitively, we expect traffic to continue backing up to the left, so the region with $\\rho=1$ will extend further and further to the left.  This corresponds to the discontinuity (or shock wave) moving to the left.  How quickly will it move?  The example below shows the solution (on the left) and individual vehicle trajectories in the $x-t$ plane (on the right)."
    ]
   },
@@ -173,9 +161,7 @@
    "metadata": {},
    "source": [
     "Returning to our traffic jam scenario, we set $\\rho_r=1$.  Then we find that \n",
-    "\n",
     "$$s = \\frac{f(\\rho_l)-f(\\rho_r)}{\\rho_l-\\rho_r} = \\frac{f(\\rho_l)}{\\rho_l-1} =  -\\rho_l.$$ \n",
-    "\n",
     "This makes sense: the traffic jam propagates back along the road, and it does so more quickly if there is a greater density of approaching cars."
    ]
   },
@@ -187,12 +173,10 @@
     "\n",
     "What about when a traffic light turns green?  At $t=0$, when the light changes, there will be a discontinuity with\n",
     "traffic backed up behind the light but little or no traffic after the light.  With the light at $x=0$, this takes the form of another Riemann problem:  \n",
-    "\n",
     "$$\n",
     "\\rho(x,t=0) = \\begin{cases} 1 & x<0, \\\\\n",
     "                            \\rho_r & x>0, \\end{cases}\n",
     "$$  \n",
-    "\n",
     "with $\\rho_r = 0$, for example.\n",
     "In this case we don't expect the discontinuity in density to propagate.  Physically, the reason is clear: after the light turns green, the cars in front accelerate and spread out; then the cars behind them accelerate, and so forth.  This kind of expansion wave is referred to as a *rarefaction wave* because the drivers experience a decrease in density (a rarefaction) as they pass through this wave.   Initially, the solution is discontinuous, but after time zero it becomes continuous."
    ]

--- a/Traffic_flow.ipynb
+++ b/Traffic_flow.ipynb
@@ -41,7 +41,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this chapter we investigate a conservation law that models the flow of traffic.  This model is sometimes referred to as the Lighthill-Whitham-Richards (or LWR) traffic model (see <cite data-cite=\"lighthill1955kinematic\"><a href=\"riemann.html#lighthill1955kinematic\">(Lighthill, 1955)</a></cite> and <cite data-cite=\"richards1956shock\"><a href=\"riemann.html#richards1956shock\">(Richards, 1956)</a></cite>).  This model and the corresponding Riemann problem are discussed in many places; the discussion here is most closely related to that in Chapter 11 of <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque, 2002)</a></cite>."
+    "In this chapter we investigate a conservation law that models the flow of traffic.  This model is sometimes referred to as the Lighthill-Whitham-Richards (or LWR) traffic model (see <cite data-cite=\"lighthill1955kinematic\"><a href=\"riemann.html#lighthill1955kinematic\">(Lighthill, 1955)</a></cite> and <cite data-cite=\"richards1956shock\"><a href=\"riemann.html#richards1956shock\">(Richards, 1956)</a></cite>).  This model and the corresponding Riemann problem are discussed in many places; the discussion here is most closely related to that in Chapter 11 of <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque, 2002)</a></cite>.\n",
+    "\n",
+    "This nonlinear scalar problem is similar to Burgers' equation that we already discussed in [Burgers](Burgers.ipynb) in many ways, since both involve a quadratic (and hence convex) flux function.  The flux for traffic flow is convex downward rather than upward, however, and the characteristic speed is no longer simply equal to the conserved variable (but is still a linear function of the density).  Although the formulas are a bit more complicated, the mathematical structure is essentially identical to Burgers', and the traffic flow model has the advantage of a nice physical interpretation of solutions that may make it easier to understand the behavior of shock and rarefaction waves and how they relate to the flow of cars, a simple one-dimensional fluid.\n",
+    "\n",
+    "In this notebook we repeat some of the discussion from [Burgers](Burgers.ipynb) in order to explain better how the mathematics relates to the fluid dynamics."
    ]
   },
   {
@@ -59,11 +63,13 @@
    "metadata": {},
    "source": [
     "## The LWR model\n",
-    "Recall the continuity equation:  \n",
+    "Recall the continuity equation for any density that is advected with a flow: \n",
+    "\n",
     "$$\\rho_t + (u\\rho)_x = 0.$$  \n",
+    "\n",
     "In this chapter, $\\rho$ represents the density of cars on a road, traveling with velocity $u$.  Note that we're not keeping track of the individual cars, but just of the average number of cars per unit length of road.  Thus $\\rho=0$ represents an empty stretch of road, and we can choose the units so that $\\rho=1$ represents bumper-to-bumper traffic.\n",
     "\n",
-    "We'll also choose units so that the speed limit is $u_\\text{max}=1$, and assume that drivers never go faster than this (yeah, right!).  If we assume that drivers always travel at a single uniform velocity, we obtain once again the advection equation that we studied in [Advection.ipynb](Advection.ipynb).  But we all know that's not accurate in practice -- cars go faster in light traffic and slower when there is congestion.  The simplest way to incorporate this effect is to make the velocity a linearly decreasing function of the density:\n",
+    "We'll also choose units so that the speed limit is $u_\\text{max}=1$, and assume that drivers never go faster than this (yeah, right!).  If we assume that drivers always travel at a single uniform velocity, we obtain once again the advection equation that we studied in [Advection](Advection.ipynb).  But we all know that's not accurate in practice -- cars go faster in light traffic and slower when there is congestion.  The simplest way to incorporate this effect is to make the velocity a linearly decreasing function of the density:\n",
     "\n",
     "$$u(\\rho) = 1 - \\rho.$$\n",
     "\n",
@@ -103,9 +109,13 @@
    "metadata": {},
    "source": [
     "This equation is fundamentally different from the advection equation because the flux is **nonlinear**.  This fact will have dramatic consequences for both the behavior of solutions and our numerical methods.  But we can superficially make this equation look like the advection equation by using the chain rule to write it in quasilinear form:  \n",
+    "\n",
     "$$f(\\rho)_x = f'(\\rho) \\rho_x = (1-2\\rho)\\rho_x.$$  \n",
+    "\n",
     "Then we have  \n",
+    "\n",
     "$$\\rho_t + (1-2\\rho)\\rho_x = 0.$$  \n",
+    "\n",
     "This is like the advection equation, but with a velocity $1-2\\rho$ that depends on the density of cars.  The value $f'(\\rho)=1-2\\rho$ is referred to as the *characteristic speed*.  This characteristic speed is not the speed at which cars move (notice that it can even be negative, whereas cars only drive to the right in our model)  Rather, it is the speed at which *information* is transmitted along the road."
    ]
   },
@@ -116,10 +126,12 @@
     "## Example: Traffic jam\n",
     "\n",
     "What does our model predict when traffic approaches a totally congested ($\\rho=1$) area?  This might be due to construction, an accident or a red light somewhere to the right; upstream of the obstruction, cars will be bumper-to-bumper, so we set $\\rho=1$ for $x>0$ (supposing that traffic has backed up to that point).  For $x<0$ we'll assume a lower density $\\rho_l<1$.  This is another example of a Riemann problem: two constant states separated by a discontinuity.  We have  \n",
+    "\n",
     "$$\n",
     "\\rho(x,t=0) = \\begin{cases} \\rho_l & x<0 \\\\\n",
     "                            1 & x>0. \\end{cases}\n",
     "$$  \n",
+    "\n",
     "What will happen as time goes forward?  Intuitively, we expect traffic to continue backing up to the left, so the region with $\\rho=1$ will extend further and further to the left.  This corresponds to the discontinuity (or shock wave) moving to the left.  How quickly will it move?  The example below shows the solution (on the left) and individual vehicle trajectories in the $x-t$ plane (on the right)."
    ]
   },
@@ -148,7 +160,9 @@
     "![Fig. 4.2: Rate of cars entering and emerging from the shock.  If the shock were stationary, these would be unequal.](./figures/shock_diagram_traffic_a.png)\n",
     "\n",
     "However, the shock is not stationary, so the line is moving.  Let $s$ be the speed of the shock.  Then as the line moves to the left, some cars that were to the left are now to the right of the line.  The rate of cars removed from the left is $s \\rho_l$ and the rate of cars added on the right is $s \\rho_r$.  So in order to avoid an accumulation of cars at the shock, these two effects need to be balanced:  \n",
+    "\n",
     "$$f(\\rho_l) - f(\\rho_r) = s(\\rho_l - \\rho_r).$$  \n",
+    "\n",
     "This condition is known as the **Rankine-Hugoniot condition**, and it holds for any shock wave in the solution of any hyperbolic system!\n",
     "\n",
     "![Fig. 4.3: The shock moves at just the necessary rate so that the same number of cars arrive from the left and emerge to the right.](./figures/shock_diagram_traffic_b.png)"
@@ -158,8 +172,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Returning to our traffic jam scenario, we set $\\rho_r=1$.  Then we find that  \n",
-    "$$s = \\frac{f(\\rho_l)-f(\\rho_r)}{\\rho_l-\\rho_r} = \\frac{f(\\rho_l)}{\\rho_l-1} =  -\\rho_l.$$  \n",
+    "Returning to our traffic jam scenario, we set $\\rho_r=1$.  Then we find that \n",
+    "\n",
+    "$$s = \\frac{f(\\rho_l)-f(\\rho_r)}{\\rho_l-\\rho_r} = \\frac{f(\\rho_l)}{\\rho_l-1} =  -\\rho_l.$$ \n",
+    "\n",
     "This makes sense: the traffic jam propagates back along the road, and it does so more quickly if there is a greater density of approaching cars."
    ]
   },
@@ -171,10 +187,12 @@
     "\n",
     "What about when a traffic light turns green?  At $t=0$, when the light changes, there will be a discontinuity with\n",
     "traffic backed up behind the light but little or no traffic after the light.  With the light at $x=0$, this takes the form of another Riemann problem:  \n",
+    "\n",
     "$$\n",
     "\\rho(x,t=0) = \\begin{cases} 1 & x<0, \\\\\n",
     "                            \\rho_r & x>0, \\end{cases}\n",
     "$$  \n",
+    "\n",
     "with $\\rho_r = 0$, for example.\n",
     "In this case we don't expect the discontinuity in density to propagate.  Physically, the reason is clear: after the light turns green, the cars in front accelerate and spread out; then the cars behind them accelerate, and so forth.  This kind of expansion wave is referred to as a *rarefaction wave* because the drivers experience a decrease in density (a rarefaction) as they pass through this wave.   Initially, the solution is discontinuous, but after time zero it becomes continuous."
    ]
@@ -291,7 +309,7 @@
    "source": [
     "## Interactive Riemann solution\n",
     "\n",
-    "Throughout this notebook we have been using code from [traffic_LWR.py](./exact_solvers/traffic_LWR.py) to provide the exact solution of the Riemann problem.  In the live notebook, the interactive module below shows the solution\n",
+    "In the live notebook, the interactive module below shows the solution\n",
     "of the Riemann problem for any inputs $(\\rho_l,\\rho_r)$ with slider bars to adjust these. The characteristics and vehicle trajectories are also plotted."
    ]
   },

--- a/exact_solvers/burgers.py
+++ b/exact_solvers/burgers.py
@@ -5,7 +5,7 @@ import sys, os
 import numpy as np
 from utils import riemann_tools
 from ipywidgets import widgets
-from utils.snapshot_widgets import interact
+from ipywidgets import interact
 from IPython.display import display
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
I talked to @ketch yesterday about possibly swapping the order of these two notebooks to put `Burgers` before `Traffic_flow` since I find it more natural to teach them in this order.  This PR has some modifications to both to make them flow better in this order as a possible revision.  I don't think David is convinced this is a good idea, so this is still open to discussion!

I fixed a few other things, but there is an interact in `Burgers` that is still broken, as discussed in #178.  I tried fiddling with this, and there does seem to be an uncaught exception in the last part of `burgers.riemann_solution_interact`.  But I didn't write this gui code and don't really understand how these more complex widgets are supposed to be working. As far as I can see what's done here is identical to what's done in the some of the acoustics widgets that work fine.  So maybe whoever wrote this code (@maojrs ?) can figure out what's going wrong? 