### PR TITLE
Add pyclaw simulation at end of SW approx notebook.

### DIFF
--- a/Shallow_water_approximate.ipynb
+++ b/Shallow_water_approximate.ipynb
@@ -886,6 +886,115 @@
     "sw.phase_plane_plot(q_l,q_r,g=1.,y_axis='u',\n",
     "                    approx_states=states['hll'])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparison of Riemann solvers within a finite volume method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let us compare the performance of the HLLE and Roe Riemann solvers when they are used within a full discretization to solve the shallow water equations.  To do so, we employ [PyClaw](http://www.clawpack.org/pyclaw/) and consider a dam-break problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from clawpack import riemann\n",
+    "from clawpack.riemann.shallow_roe_with_efix_1D_constants import depth, momentum, num_eqn\n",
+    "\n",
+    "def setup(riemann_solver='roe',n=20,IC='dam-break'):\n",
+    "\n",
+    "    from clawpack import pyclaw\n",
+    "\n",
+    "    if riemann_solver.lower() == 'roe':\n",
+    "        rs = riemann.shallow_roe_with_efix_1D\n",
+    "    elif riemann_solver.lower() == 'hlle':\n",
+    "        rs = riemann.shallow_hlle_1D\n",
+    " \n",
+    "    solver = pyclaw.ClawSolver1D(rs)\n",
+    "        \n",
+    "    solver.bc_lower[0] = pyclaw.BC.extrap\n",
+    "    solver.bc_upper[0] = pyclaw.BC.extrap\n",
+    "\n",
+    "    xlower = -5.0\n",
+    "    xupper = 5.0\n",
+    "    x = pyclaw.Dimension(xlower,xupper,n,name='x')\n",
+    "    domain = pyclaw.Domain(x)\n",
+    "    state = pyclaw.State(domain,num_eqn)\n",
+    "\n",
+    "    # Gravitational constant\n",
+    "    state.problem_data['grav'] = 1.0\n",
+    "    state.problem_data['dry_tolerance'] = 1e-3\n",
+    "    state.problem_data['sea_level'] = 0.0\n",
+    "    \n",
+    "    xc = state.grid.x.centers\n",
+    "\n",
+    "    x0=0.\n",
+    "\n",
+    "    hl = 10.\n",
+    "    ul = 0.\n",
+    "    hr = 0.5\n",
+    "    ur = 0.\n",
+    "    state.q[depth,:] = hl * (xc <= x0) + hr * (xc > x0)\n",
+    "    state.q[momentum,:] = hl*ul * (xc <= x0) + hr*ur * (xc > x0)\n",
+    "\n",
+    "    claw = pyclaw.Controller()\n",
+    "    claw.keep_copy = True\n",
+    "    claw.output_format = None\n",
+    "    claw.tfinal = 1.0\n",
+    "    claw.solution = pyclaw.Solution(state,domain)\n",
+    "    claw.solver = solver\n",
+    "\n",
+    "    return claw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n=40\n",
+    "roe = setup(riemann_solver='roe',n=n)\n",
+    "roe.verbosity = 0\n",
+    "status = roe.run()\n",
+    "\n",
+    "hlle = setup(riemann_solver='hlle',n=n)\n",
+    "hlle.verbosity = 0\n",
+    "status = hlle.run()\n",
+    "\n",
+    "q_l = [10,0]\n",
+    "q_r = [0.5,0]\n",
+    "states, speeds, reval, wave_types = \\\n",
+    "                sw.exact_riemann_solution(q_l, q_r)\n",
+    "def plot_frame(i):\n",
+    "    h_roe = roe.frames[i].q[0,:]\n",
+    "    h_hlle = hlle.frames[i].q[0,:]\n",
+    "    x = roe.grid.x.centers\n",
+    "    t = roe.frames[i].t+1.e-13\n",
+    "    plt.plot(x,h_roe,'-o')\n",
+    "    plt.plot(x,h_hlle,'-o')\n",
+    "    xis = np.linspace(-5/t,5/t,200)\n",
+    "    plt.plot(xis*t,[reval(xi)[0] for xi in xis],'-k')\n",
+    "    plt.legend(['Roe','HLLE'])\n",
+    "    \n",
+    "interact(plot_frame, i=widgets.IntSlider(min=0,max=10,value=0));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clearly, both solvers give very similar results for this problem.  They converge to the same solution, as you can verify by increasing the value of $n$ above."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
When I taught from this chapter, I felt that there ought to be a comparison of full FV solutions using the two Riemann solvers at the end.  This PR adds a PyClaw dam-break simulation with Roe and HLLE.  The basic takeaway is that the two solvers give almost the same solution on any reasonable grid, despite the fact that the underlying approximate Riemann solutions are so different.  I think it is important for students to be aware of this.

I'm open for suggestions of other things to include.