### PR TITLE
Syntax highlight

### DIFF
--- a/Burgers.ipynb
+++ b/Burgers.ipynb
@@ -47,7 +47,7 @@
     "To examine the Python code for this chapter, see:\n",
     "\n",
     " - [exact_solvers/burgers.py](exact_solvers/pandoc/burgers.html)\n",
-    " - [exact_solvers/burgers_demos.py](exact_solvers/pandocburgers_demos.html)"
+    " - [exact_solvers/burgers_demos.py](exact_solvers/pandoc/burgers_demos.html)"
    ]
   },
   {

--- a/Burgers.ipynb
+++ b/Burgers.ipynb
@@ -46,8 +46,8 @@
     "\n",
     "To examine the Python code for this chapter, see:\n",
     "\n",
-    " - [exact_solvers/burgers.py](exact_solvers/burgers.py)\n",
-    " - [exact_solvers/burgers_demos.py](exact_solvers/burgers_demos.py)"
+    " - [exact_solvers/burgers.py](exact_solvers/pandoc/burgers.html)\n",
+    " - [exact_solvers/burgers_demos.py](exact_solvers/pandocburgers_demos.html)"
    ]
   },
   {

--- a/utils/syntax_highlight.py
+++ b/utils/syntax_highlight.py
@@ -1,0 +1,77 @@
+"""
+From the top directory run
+    python utils/syntax_highlight.py
+in order to create .html versions of all the .py files in 
+    exact_solvers/ and put them in exact_solvers/pandoc/
+    utils/ and put them in utils/pandoc
+
+Then in a notebook use markdown like this to refer to them:
+
+    To examine the Python code for this chapter, see:
+
+     - [exact_solvers/burgers.py](exact_solvers/pandoc/burgers.html)
+     - [exact_solvers/burgers_demos.py](exact_solvers/pandocburgers_demos.html)
+
+Also makes an index.html file in each pandoc directory.
+"""
+
+
+import os,sys,glob
+
+hstyle = 'tango'     # light background
+#hstyle = 'zenburn'   # dark background
+
+topdir = os.getcwd()
+
+#------------------------
+header = """...
+
+From [https://github.com/clawpack/riemann_book](https://github.com/clawpack/riemann_book)
+
+```python
+"""  
+#------------------------
+
+for pydir in ['exact_solvers', 'utils']:
+
+    os.chdir(pydir)
+
+    os.system('mkdir -p pandoc')
+    index_file = os.path.join('pandoc','index.html')
+    index = open(index_file,'w')
+    index.write('<html><h1>Python code in %s</h1>\n' % pydir)
+    index.write('<ul>\n')
+
+    py_files = glob.glob('*.py')
+    for py_name in py_files:
+
+        #if py_name != 'burgers.py': continue  # to test on one file
+
+        f = open(py_name).read()
+
+        # make a new version for a .md file that has the code in a
+        # ```python ... ```  code block, and a title at the top:
+
+        title = "---\ntitle: %s/%s\n" % (pydir,py_name)
+
+        f2 = title + header + f + '\n```\n'
+
+        md_name = os.path.join('pandoc', os.path.splitext(py_name)[0] + '.md')
+        with open(md_name, 'w') as tfile:
+            tfile.write(f2)
+
+        # run pandoc to perform syntax highlighting and produce html:
+
+        html_name = os.path.join('pandoc', os.path.splitext(py_name)[0] + '.html')
+        cmd = 'pandoc %s -s --highlight-style %s -o %s' % (md_name,hstyle,html_name)
+        print(cmd)
+        os.system(cmd)
+
+        os.system('rm %s' % md_name)  # remove markdown version
+
+        index.write('<li> <a href="%s">%s</a>' \
+            % (os.path.splitext(py_name)[0] + '.html', py_name))
+    
+    index.write('</ul>\n</html>\n')
+    index.close()
+    os.chdir(topdir)

--- a/utils/syntax_highlight.py
+++ b/utils/syntax_highlight.py
@@ -32,46 +32,75 @@ From [https://github.com/clawpack/riemann_book](https://github.com/clawpack/riem
 """  
 #------------------------
 
-for pydir in ['exact_solvers', 'utils']:
+def make_highlighted_html(pydir, py_name):
+    pandir = os.path.join(pydir, 'pandoc')
+    os.system('mkdir -p %s' % pandir)
+    py_path = os.path.join(pydir, py_name)
 
-    os.chdir(pydir)
+    f = open(py_path).read()
 
-    os.system('mkdir -p pandoc')
-    index_file = os.path.join('pandoc','index.html')
-    index = open(index_file,'w')
-    index.write('<html><h1>Python code in %s</h1>\n' % pydir)
-    index.write('<ul>\n')
+    # make a new version for a .md file that has the code in a
+    # ```python ... ```  code block, and a title at the top:
 
-    py_files = glob.glob('*.py')
-    for py_name in py_files:
+    title = "---\ntitle: %s/%s\n" % (pydir,py_name)
 
-        #if py_name != 'burgers.py': continue  # to test on one file
+    f2 = title + header + f + '\n```\n'
 
-        f = open(py_name).read()
+    md_name = os.path.join(pydir, 'pandoc', os.path.splitext(py_name)[0] + '.md')
+    with open(md_name, 'w') as tfile:
+        tfile.write(f2)
 
-        # make a new version for a .md file that has the code in a
-        # ```python ... ```  code block, and a title at the top:
+    # run pandoc to perform syntax highlighting and produce html:
 
-        title = "---\ntitle: %s/%s\n" % (pydir,py_name)
+    html_name = os.path.join(pydir, 'pandoc', os.path.splitext(py_name)[0] + '.html')
+    cmd = 'pandoc %s -s --highlight-style %s -o %s' % (md_name,hstyle,html_name)
+    print(cmd)
+    os.system(cmd)
 
-        f2 = title + header + f + '\n```\n'
+    os.system('rm %s' % md_name)  # remove markdown version
 
-        md_name = os.path.join('pandoc', os.path.splitext(py_name)[0] + '.md')
-        with open(md_name, 'w') as tfile:
-            tfile.write(f2)
+if __name__=='__main__':
 
-        # run pandoc to perform syntax highlighting and produce html:
+    for pydir in ['exact_solvers', 'utils']:
 
-        html_name = os.path.join('pandoc', os.path.splitext(py_name)[0] + '.html')
-        cmd = 'pandoc %s -s --highlight-style %s -o %s' % (md_name,hstyle,html_name)
-        print(cmd)
-        os.system(cmd)
+        os.chdir(pydir)
 
-        os.system('rm %s' % md_name)  # remove markdown version
+        os.system('mkdir -p pandoc')
+        index_file = os.path.join('pandoc','index.html')
+        index = open(index_file,'w')
+        index.write('<html><h1>Python code in %s</h1>\n' % pydir)
+        index.write('<ul>\n')
 
-        index.write('<li> <a href="%s">%s</a>' \
-            % (os.path.splitext(py_name)[0] + '.html', py_name))
-    
-    index.write('</ul>\n</html>\n')
-    index.close()
-    os.chdir(topdir)
+        py_files = glob.glob('*.py')
+        for py_name in py_files:
+
+            #if py_name != 'burgers.py': continue  # to test on one file
+
+            f = open(py_name).read()
+
+            # make a new version for a .md file that has the code in a
+            # ```python ... ```  code block, and a title at the top:
+
+            title = "---\ntitle: %s/%s\n" % (pydir,py_name)
+
+            f2 = title + header + f + '\n```\n'
+
+            md_name = os.path.join('pandoc', os.path.splitext(py_name)[0] + '.md')
+            with open(md_name, 'w') as tfile:
+                tfile.write(f2)
+
+            # run pandoc to perform syntax highlighting and produce html:
+
+            html_name = os.path.join('pandoc', os.path.splitext(py_name)[0] + '.html')
+            cmd = 'pandoc %s -s --highlight-style %s -o %s' % (md_name,hstyle,html_name)
+            print(cmd)
+            os.system(cmd)
+
+            os.system('rm %s' % md_name)  # remove markdown version
+
+            index.write('<li> <a href="%s">%s</a>' \
+                % (os.path.splitext(py_name)[0] + '.html', py_name))
+        
+        index.write('</ul>\n</html>\n')
+        index.close()
+        os.chdir(topdir)


### PR DESCRIPTION
I wrote a script to use pandoc to convert each .py file that we link to from notebooks into a syntax-highlighted .html file like this example: http://staff.washington.edu/rjl/misc/burgers.html

This also has the advantage that it always opens the file in the browser, whereas depending on ones browser setting, clicking on a link to a .py file might just download it rather than displaying it.

What do you think? If you like it we need to make similar changes in all notebooks that link to exact solvers.  

We might also want a notebook or index at least of all the code in `utils` for readers who want to examine these.

By the way I put this script in utils and I think we should move other utilities like `make_pdf.py` there eventually so the main directory isn't cluttered up, to make it easier for the reader to find the notebooks.
