### PR TITLE
Dockerfile that uses clawpack-v5.6.0 from dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,72 +1,33 @@
-FROM ubuntu:16.04
 
-# Install some useful tools + gfortran
-RUN apt-get update \
- && apt-get install -yq \
-    locales \
-    dialog \
-    net-tools \
-    tar \
-    git \
-    nano \
-    vim \
-    curl \
-    wget \
-    gfortran \
-    build-essential \
-    python \
-    python-dev \
-    virtualenv \
-    && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+FROM clawpack/v5.6.0_dockerimage:release
+# this dockerhub image has a user jovyan and clawpack installed 
+# in /home/jovyan/clawpack-v5.6.0
 
-RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
-    locale-gen
 
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
-ENV VIRTUAL_ENV /srv/venv
-ENV PATH ${VIRTUAL_ENV}/bin:${PATH}
-
-# Use bash as default shell, rather than sh
-ENV SHELL /bin/bash
-
-# Set up user
 ENV NB_USER jovyan
-ENV NB_UID 1000
-ENV HOME /home/${NB_USER}
-
-RUN adduser --disabled-password \
-    --gecos "Default user" \
-    --uid ${NB_UID} \
-    ${NB_USER}
+User jovyan
 
 WORKDIR ${HOME}
 
-RUN mkdir -p ${VIRTUAL_ENV} && chown ${NB_USER}:${NB_USER} ${VIRTUAL_ENV}
-
-User jovyan
-
-RUN virtualenv ${VIRTUAL_ENV}
-ENV PYTHONHOME ${VIRTUAL_ENV}
 
 # Install notebook extensions
-RUN pip install --no-cache-dir \
-    jupyter \
-    jupyter_contrib_nbextensions \
-    jupyterhub-legacy-py2-singleuser==0.7.2
+#RUN pip install --user --no-cache-dir \
+    #jupyter \
+    #jupyter_contrib_nbextensions \
+    #jupyterhub-legacy-py2-singleuser==0.7.2
 
+RUN git clone https://github.com/ipython-contrib/jupyter_contrib_nbextensions.git
+RUN pip install --user -e jupyter_contrib_nbextensions
+
+ENV PATH ${PATH}:/home/jovyan/.local/bin
 RUN jupyter contrib nbextension install --user
 RUN jupyter nbextension enable widgetsnbextension --py
 RUN jupyter nbextension enable equation-numbering/main
 
-# Install clawpack-v5.4.0:
-RUN pip2 install --src=$HOME/clawpack -e git+https://github.com/clawpack/clawpack.git@v5.4.0#egg=clawpack-v5.4.0
 
 # Add book's files
 RUN git clone --depth=1 https://github.com/clawpack/riemann_book
 
-RUN pip install --no-cache-dir -r $HOME/riemann_book/requirements.txt
+RUN pip install --user --no-cache-dir -r $HOME/riemann_book/requirements.txt
 
-CMD jupyter notebook --ip='*' --no-browser
+CMD jupyter notebook riemann_book/Index.ipynb --ip='*' --no-browser


### PR DESCRIPTION
This Dockerfile is much simpler and loads on binder much more quickly since it is based on the docker image for clawpack-v5.6.0 on dockerhub.

I just tested this again on binder and it seems to work fine.  Try it at:

https://mybinder.org/v2/gh/rjleveque/riemann_book/Dockerfile_v5.6.0
