### PR TITLE
Update Dockerfile

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -3,30 +3,48 @@
 
 **Note:** In the instructions below, 
  - `$` refers to the native bash shell prompt on your computer, 
- - `root@...#` refers to the bash shell prompt within the Docker container, once you have that running.
+ - `jovyan $` refers to the bash shell prompt within the Docker container, once you have that running.
 
 First install [Docker](https://www.docker.com/).  If it is installed, make sure it is running.
 
-Then, in this directory (containing the file `Dockerfile`), do:
-
-    $ docker build -t riemann_book_dockerimage .
-
-Don't forget the last `.` on this line!
-
 Then do:
 
-    $ docker run -it -p 8888:8888 --name riemann_book_container riemann_book_dockerimage
+    $ docker run -i -t -p 8889:8889 --name rbook_container clawpack/rbook
 
-This starts a virtual machine (*container*) named `riemann_book_container` and starts a Jupyter Notebook server.
-You should see a URL to copy paste into a browser to start your notebook, such as
+This starts a virtual machine (*container*) named `rbook_container` based on the docker image `clawpack/rbook` that is available on [dockerhub](https://hub.docker.com/r/clawpack/rbook).
 
-    http://localhost:8888/?token=9542fb1ed940f873f28e6a371c6334c5b1a0d8656121905c
+If the container starts properly, you will now see the `jovyan $` prompt in your shell window.  You are in a bash shell and can move around and examine files as desired.
 
-This should open a web page with the list of all available notebooks.  You can start with `Index.ipynb`,
-or click on any notebook to launch.
+### Start the notebook server
 
-To close the notebook and exit the container, you can press Ctrl-C. If you want to run the container in
-the background and not take up your terminal, simply omit the `-it` options to `docker run` command.
+To start a Jupyter notebook server that is serving these Riemann notebooks, execute the following in the container:
+
+    jovyan $ jupyter notebook --ip=0.0.0.0 --port=8889 --no-browser
+
+The port number 8889 should agree with the port number you
+specified in the `docker run` command. This is the port on
+which the notebooks will be served.
+
+In the output of this command, you should see a URL to copy paste
+into a browser to start your notebook, such as:
+
+     To access the notebook, open this file in a browser ...
+     Or copy and paste one of these URLs: ...     
+       http://127.0.0.1:8889/?token=TOKEN
+
+where `TOKEN` is a long hexidecimal string.  
+
+If you paste this last URL into a browser (with the `TOKEN` supplied)
+it should take you to a web page displaying the top level directory.  
+
+Navigate to `riemann_book` directory.
+Then you can start with `Index.ipynb`, or click on any notebook to launch.
+
+To close the notebook server, you can press Ctrl-C in the container bash shell. 
+
+Then to exit the container:
+
+    jovyan $ exit
 
 See http://jupyter.org/ for more documentation on Jupyter.
 
@@ -34,39 +52,36 @@ See http://jupyter.org/ for more documentation on Jupyter.
 
 If you have the notebook server running and also want another window open with a bash shell, in another shell on your laptop you can do:
 
-    $ docker exec -it riemann_book_container bash
+    $ docker exec -it rbook_container bash
 
 ### Updating the riemann_book files
 
-In case the `riemann_book` repository changed since you built the docker image, you could do:
+In case the `riemann_book` repository changed since the  docker image was built, you could do:
 
-    root@...# cd $HOME/riemann_book
-    root@...# git pull
+    jovyan $ cd $HOME/riemann_book
+    jovyan $ git pull
     
 ### Updating `clawpack/riemann`
 
+*This should not be necessary with the latest version.*
+
 You may need some Riemann solvers not in the most recent release of Clawpack.  These can be obtained by checking out the master branch (and pulling any changes since you built the image, if necessary):
 
-    root@...# cd $HOME/clawpack/clawpack-5.4.0/riemann
-    root@...# git checkout master
-    root@...# git pull
+    jovyan $ cd $HOME/clawpack/clawpack-5.6.1/riemann
+    jovyan $ git checkout master
+    jovyan $ git pull
 
 If this brings down new Riemann solvers, you will need to compile them and re-install clawpack:
 
-    root@...# cd $HOME/clawpack/clawpack-5.4.0
-    root@...# pip2 install -e .
+    jovyan $ cd $HOME/clawpack/clawpack-5.6.1
+    jovyan $ pip2 install -e .
     
-### Update to the latest version of the notebooks
-
-    root@...# cd $HOME
-    root@...# git checkout master
-    root@...# git pull
     
 ### Restarting a container
 
 You can restart the container via::
 
-    $ docker start -a -i riemann_book_container
+    $ docker start -a -i rbook_container
 
 The external port should still work for serving notebooks.
 
@@ -74,17 +89,29 @@ The external port should still work for serving notebooks.
 
 This gets rid of the container and any data that you might have created when running this container:
 
-    $ docker rm riemann_book_container
+    $ docker rm rbook_container
     
 ### Removing the image
 
-You might want to do this if you need to rebuild an image with an updated Dockerfile or to incorporate a newer version of software:
+Do this if you don't plan to use the image again and want to clean up:
 
-    $ docker rmi riemann_book_dockerimage
+    $ docker rmi clawpack/rbook
     
+### Creating a docker image:
+
+The docker image that is available on dockerhub as `clawpack/rbook` was built with this command:
+
+    $ docker build -t clawpack/rbook -f Dockerfile .
+
+If you want to create your own docker image that can run the notebooks, and perhaps also includes some of your own, for example, you could modify `Dockerfile` as desired to `myDockerfile` and then do:
+
+    $ docker build -t my_rbook_image -f myDockerfile .
+
+Note the last `.` on this line!
+
+
 ### More resources:
 
  - [Docker for Clawpack](http://www.clawpack.org/docker_image.html#docker-image).  The Dockerfile provided here includes everything in the Clawpack-5.4.0 image.
  
- - [Introduction to Docker](https://geohackweek.github.io/Introductory/01-docker-tutorial/) from 
-   the recent [GeoHack Week](https://geohackweek.github.io) at UW.
+ - [Docker documentation](https://docs.docker.com/)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
-FROM clawpack/v5.6.0_dockerimage:release
+FROM clawpack/v5.6.1_dockerimage:release
 # this dockerhub image has a user jovyan and clawpack installed 
-# in /home/jovyan/clawpack-v5.6.0
+# in /home/jovyan/clawpack-v5.6.1
 
 
 ENV NB_USER jovyan
@@ -10,13 +10,8 @@ User jovyan
 WORKDIR ${HOME}
 
 
-# Install notebook extensions
-#RUN pip install --user --no-cache-dir \
-    #jupyter \
-    #jupyter_contrib_nbextensions \
-    #jupyterhub-legacy-py2-singleuser==0.7.2
-
 RUN git clone https://github.com/ipython-contrib/jupyter_contrib_nbextensions.git
+RUN pip install ipywidgets
 RUN pip install --user -e jupyter_contrib_nbextensions
 
 ENV PATH ${PATH}:/home/jovyan/.local/bin
@@ -30,4 +25,8 @@ RUN git clone --depth=1 https://github.com/clawpack/riemann_book
 
 RUN pip install --user --no-cache-dir -r $HOME/riemann_book/requirements.txt
 
-CMD jupyter notebook riemann_book/Index.ipynb --ip='*' --no-browser
+# The command below starts the notebook server, but better to not
+# do this by default in case the user also wants to examine files or use
+# the docker container for running other things...
+#CMD jupyter notebook riemann_book/Index.ipynb --ip=0.0.0.0 --port=8889 --no-browser
+

--- a/README.md
+++ b/README.md
@@ -59,21 +59,15 @@ instructions.
 
 ## Execute in the cloud
 
-### Windows Azure
-
-Rather than installing software, you can execute the notebooks on the cloud
-using the [Microsoft Azure Notebooks](https://notebooks.azure.com) cloud
-service:  Create a free account and then clone the [riemann_book
-library](https://notebooks.azure.com/rjleveque/libraries/riemann-book).
-*These may not be up to date with the versions in this repository during the
-development phase of this project.*
-
 ### Binder
 
-This is still under development using the latest version of
-[binder](https://beta.mybinder.org/).  You can try it out for these notebooks
-at this link: https://beta.mybinder.org/v2/gh/clawpack/riemann_book/master
+Rather than installing anything on your own computer, you can run the
+notebooks on the cloud using the free
+[binder](https://mybinder.org/) service.  
+Simply navigate to this link in a browser:
 
-This should start up a notebook server on a
-[Jupyterhub](https://jupyterhub.readthedocs.io/en/latest/) that lets you
-execute all the notebooks with no installation required.
+    https://mybinder.org/v2/gh/clawpack/riemann_book/master
+
+This may take a few minutes to start up a notebook server on a
+[Jupyterhub](https://jupyterhub.readthedocs.io/en/latest/). Then navigate to
+`riemann_book` and open `Index.ipynb` to get started.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,15 @@ for reading the notebooks is given in `Index.ipynb`.
 ## Docker
 
 Rather than installing all the dependencies, if you have
-[Docker](https://www.docker.com/) installed you can use the `Dockerfile` in
-this repository.  See `Docker.md` for instructions.
+[Docker](https://www.docker.com/) installed you can use
 
-*[Add instructions for Dockerhub]*
+    $ docker pull clawpack/rbook
+
+to obtain a docker image that has all the notebooks and dependencies
+installed.  This was built using the `Dockerfile` in
+this repository, which could be modified to build a new image also
+containing other material, if desired.  See `Docker.md` for further
+instructions.
 
 ## Execute in the cloud
 


### PR DESCRIPTION
The updated Dockerfile:
 - uses v5.6.1
 - does not start the notebook server in the container automatically, since the user might want to do something else.

I also updated the documentation about how to use it.

Note that the docker image has now been pushed to dockerhub as `clawpack/rbook` so the user can just pull from there and no longer needs to build the image.

This seems to work fine on binder as well, and I updated those links in the README.

I also eliminated the links to Azure since that's not up to date and I suggest we stick to just supporting binder for now since that seems to be working well.
