### PR TITLE
github punctuation

### DIFF
--- a/Acoustics.ipynb
+++ b/Acoustics.ipynb
@@ -50,9 +50,9 @@
     "If you wish to examine the Python code for this chapter, please see:\n",
     "\n",
     " - [exact_solvers/acoustics.py](exact_solvers/acoustics.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/acoustics.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/acoustics.py)\n",
     " - [exact_solvers/acoustics_demos.py](exact_solvers/acoustics_demos.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/acoustics_demos.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/acoustics_demos.py)"
    ]
   },
   {

--- a/Advection.ipynb
+++ b/Advection.ipynb
@@ -16,7 +16,7 @@
     "To examine the Python code for this chapter, see:\n",
     "\n",
     " - [exact_solvers/advection.py](exact_solvers/advection.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/advection.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/advection.py)"
    ]
   },
   {

--- a/Burgers.ipynb
+++ b/Burgers.ipynb
@@ -8,7 +8,6 @@
    ]
   },
   {
-
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -41,7 +40,6 @@
    ]
   },
   {
-
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -50,9 +48,9 @@
     "To examine the Python code for this chapter, see:\n",
     "\n",
     " - [exact_solvers/burgers.py](exact_solvers/burgers.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/burgers.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/burgers.py)\n",
     " - [exact_solvers/burgers_demos.py](exact_solvers/burgers_demos.py)...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/burgers_demos.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/burgers_demos.py)"
    ]
   },
   {

--- a/Burgers_approximate.ipynb
+++ b/Burgers_approximate.ipynb
@@ -83,7 +83,7 @@
     "To examine the Python code for this chapter, see:\n",
     "\n",
     " - [exact_solvers/burgers.py](exact_solvers/burgers.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/burgers.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/burgers.py)"
    ]
   },
   {

--- a/Euler.ipynb
+++ b/Euler.ipynb
@@ -265,9 +265,9 @@
     "If you wish to examine the Python code for this chapter, see:\n",
     "\n",
     "- [exact_solvers/euler.py](exact_solvers/euler.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/euler.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/euler.py)\n",
     "- [exact_solvers/euler_demos.py](exact_solvers/euler_demos.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/euler_demos.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/euler_demos.py)"
    ]
   },
   {

--- a/FV_compare.ipynb
+++ b/FV_compare.ipynb
@@ -21,8 +21,8 @@
     "  \n",
     "In this chapter we include extensive sections of code in the notebook.  This is meant to more easily allow the reader to use these as templates for setting up other problems in PyClaw. For the code in this chapter we use approximate Riemann solvers from PyClaw that can be found in these files:\n",
     "\n",
-    "- [euler_1D_py.py](https://github.com/clawpack/riemann/blob/master/riemann/euler_1D_py.py),\n",
-    "- [shallow_roe_with_efix_1D](https://github.com/clawpack/riemann/blob/master/riemann/shallow_1D_py.py),"
+    "- [euler_1D_py.py,](https://github.com/clawpack/riemann/blob/master/riemann/euler_1D_py.py)\n",
+    "- [shallow_roe_with_efix_1D.](https://github.com/clawpack/riemann/blob/master/riemann/shallow_1D_py.py)"
    ]
   },
   {

--- a/Introduction.ipynb
+++ b/Introduction.ipynb
@@ -24,7 +24,7 @@
     "The plots shown in this chapter are created using a function that is defined in the Python module \n",
     "\n",
     " - [exact_solvers/shallow_water.py](exact_solvers/shallow_water.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_water.py)\n",
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_water.py)\n",
     "\n",
     "In all of the notebooks, much of the Python code that is used behind the scenes is imported from modules in the `exact_solvers` subdirectory, including the grungy details to make nice plots.  Much of the code for actually solving the Riemann problems is also in these modules, so if you want to dive into the implementations, you will need to examine that code.  Near the top of each notebook there is a link to the relevant modules for that chapter.  The versions on Github may be nicer to read since the syntax is automatically highlighted.\n",
     "\n",

--- a/Nonconvex_scalar.ipynb
+++ b/Nonconvex_scalar.ipynb
@@ -75,9 +75,9 @@
     "If you wish to examine the Python code for this chapter, please see:\n",
     "\n",
     " - [exact_solvers/nonconvex.py](exact_solvers/nonconvex.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/nonconvex.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/nonconvex.py)\n",
     " - [exact_solvers/nonconvex_demos.py](exact_solvers/nonconvex_demos.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/nonconvex_demos.py)\n"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/nonconvex_demos.py)\n"
    ]
   },
   {

--- a/Shallow_tracer.ipynb
+++ b/Shallow_tracer.ipynb
@@ -74,9 +74,9 @@
     "If you wish to examine the Python code for this chapter, see\n",
     "\n",
     " - [exact_solvers/shallow_water.py](exact_solvers/shallow_water.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_water.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_water.py)\n",
     " - [exact_solvers/shallow_demos.py](exact_solvers/shallow_demos.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_demos.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_demos.py)"
    ]
   },
   {

--- a/Shallow_water.ipynb
+++ b/Shallow_water.ipynb
@@ -89,9 +89,9 @@
     "If you wish to examine the Python code for this chapter, see\n",
     "\n",
     " - [exact_solvers/shallow_water.py](exact_solvers/shallow_water.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_water.py),\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_water.py)\n",
     " - [exact_solvers/shallow_demos.py](exact_solvers/shallow_demos.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_demos.py)."
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_demos.py)"
    ]
   },
   {

--- a/Traffic_flow.ipynb
+++ b/Traffic_flow.ipynb
@@ -23,9 +23,9 @@
     "If you wish to examine the Python code for this chapter, please see:\n",
     "\n",
     " - [exact_solvers/traffic_LWR.py](exact_solvers/traffic_LWR.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/traffic_LWR.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/traffic_LWR.py)\n",
     " - [exact_solvers/traffic_demos.py](exact_solvers/traffic_demos.py) ...\n",
-    "   [on github](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/traffic_demos.py)\n"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/traffic_demos.py)\n"
    ]
   },
   {


### PR DESCRIPTION
Add commas and periods to github links, in a way that the footnotes render properly
in latex with the footnote superscripts after the punctuation.