### PR TITLE
in Burgers, the import statements appeared twice

### DIFF
--- a/Burgers.ipynb
+++ b/Burgers.ipynb
@@ -8,38 +8,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "%config InlineBackend.figure_format = 'svg'\n",
-    "from ipywidgets import interact\n",
-    "from ipywidgets import widgets\n",
-    "from ipywidgets import FloatSlider, fixed\n",
-    "from exact_solvers import burgers\n",
-    "from exact_solvers import burgers_demos\n",
-    "from IPython.display import HTML"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -82,15 +50,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Shock formation\n",
-    "\n",
-    "In the figure below we consider Burgers' equation with a Gaussian hump as the initial data.  Since the characteristic speed in Burgers' equation is given by $q$ itself, the peak of the hump travels faster than the rest, and characteristics are converging at the front of the traveling wave (where $f'(q)$ decreases with $x$) while they are spreading out behind the peak (where $f'(q)$ increases with $x$).  The dashed line shows the initial condition while the solid lines show the solution at later times."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -118,7 +77,17 @@
     "from ipywidgets import widgets\n",
     "from ipywidgets import FloatSlider, fixed\n",
     "from exact_solvers import burgers\n",
-    "from exact_solvers import burgers_demos"
+    "from exact_solvers import burgers_demos\n",
+    "from IPython.display import HTML"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Shock formation\n",
+    "\n",
+    "In the figure below we consider Burgers' equation with a Gaussian hump as the initial data.  Since the characteristic speed in Burgers' equation is given by $q$ itself, the peak of the hump travels faster than the rest, and characteristics are converging at the front of the traveling wave (where $f'(q)$ decreases with $x$) while they are spreading out behind the peak (where $f'(q)$ increases with $x$).  The dashed line shows the initial condition while the solid lines show the solution at later times."
    ]
   },
   {


### PR DESCRIPTION
I removed from both places and relocated to where they seem least disruptive, before the "shock formation" section.