### PR TITLE
fix float index in riemann_tools

### DIFF
--- a/utils/riemann_tools.py
+++ b/utils/riemann_tools.py
@@ -569,7 +569,7 @@ def compute_riemann_trajectories(states, s, riemann_eval, wave_types=None,
     xx = np.hstack((xx_left, xx_right))
     x_traj = [xx]
 
-    nsteps = 200.
+    nsteps = 200
     dt = 1./nsteps
     t_traj = np.linspace(0,1,nsteps+1)
     q_old = riemann_eval(xx/1e-15)


### PR DESCRIPTION
Using float steps in `np.linspace` was deprecated in numpy 1.12 and removed in 1.18 with [this commit](https://github.com/numpy/numpy/commit/f4dfe833e3e037bb69113f7250fad3699f918cfc).

With this change `make_pdf.py` runs and produces the pdf.