### PR TITLE
Resized new acoustics figure

### DIFF
--- a/Acoustics.ipynb
+++ b/Acoustics.ipynb
@@ -33,7 +33,7 @@
     "%config InlineBackend.figure_format = 'svg'\n",
     "import numpy as np\n",
     "from exact_solvers import acoustics, acoustics_demos\n",
-    "from IPython.display import IFrame, HTML"
+    "from IPython.display import IFrame, HTML, Image"
    ]
   },
   {
@@ -210,9 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "acoustics_demos.decompose_q_interactive()"
@@ -268,10 +266,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "![Fig 4.1: Structure of the Riemann solution for acoustics.](./figures/acoustics_xt_plane.png)"
+    "Image('figures/acoustics_xt_plane.png', width=350)"
    ]
   },
   {
@@ -491,7 +491,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.2"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
The new acoustics figure was being rendered very large in the notebook, so I embedded the picture using Image from Ipython display, like done in the Traffic flow notebook. Sorry for the double pull request.