### PR TITLE
change blob/master to blob/FA16 in pointers to GitHub repositories

### DIFF
--- a/Acoustics.ipynb
+++ b/Acoustics.ipynb
@@ -50,9 +50,9 @@
     "If you wish to examine the Python code for this chapter, please see:\n",
     "\n",
     " - [exact_solvers/acoustics.py](exact_solvers/acoustics.py) ...\n",
-    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/acoustics.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/acoustics.py)\n",
     " - [exact_solvers/acoustics_demos.py](exact_solvers/acoustics_demos.py) ...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/acoustics_demos.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/acoustics_demos.py)"
    ]
   },
   {

--- a/Acoustics_heterogeneous.ipynb
+++ b/Acoustics_heterogeneous.ipynb
@@ -65,7 +65,7 @@
     "\n",
     "are the spatially dependent sound speed and impedance.\n",
     "\n",
-    "In order to solve these equations, we need to do a numerical discretization. Following the spirit of finite volume methods, we approximate $\\rho(x)$ and $K(x)$ by piecewise constant functions that are constant in any given grid cell. Therefore, if we can solve the Riemann problem across two given cells, we can extrapolate the solution to the whole grid using standard finite volume method techniques, see <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)<a></cite>. The Riemann problem to solve consists of the acoustic equations Riemann problem with discontinuous initial data and coefficients (discontinuous $\\rho$ and $K$). Once this problem is solved it can be used to approximate a continuous density varying material or other similar examples. As the value of $\\rho$ and $K$ is different on the left side than on the right side, the eigenvalues and eigenvectors are as follows. The eigenvalues will be given by the sound speed in each of the two mediums,\n",
+    "In order to solve these equations, we need to do a numerical discretization. Following the spirit of finite volume methods, we approximate $\\rho(x)$ and $K(x)$ by piecewise constant functions that are constant in any given grid cell. Therefore, if we can solve the Riemann problem across two given cells, we can extrapolate the solution to the whole grid using standard finite volume method techniques, see <cite data-cite=\"fvmhp\"><a href=\"riemann.html#fvmhp\">(LeVeque 2002)</a></cite>. The Riemann problem to solve consists of the acoustic equations Riemann problem with discontinuous initial data and coefficients (discontinuous $\\rho$ and $K$). Once this problem is solved it can be used to approximate a continuous density varying material or other similar examples. As the value of $\\rho$ and $K$ is different on the left side than on the right side, the eigenvalues and eigenvectors are as follows. The eigenvalues will be given by the sound speed in each of the two mediums,\n",
     "\n",
     "\\begin{align}\n",
     "s_l = -c_l  \\ \\ \\ \\ \\ s_r = c_r \\ \\ \\ \\ \\ \\mathrm{with:} \\ \\ \\ \\ \\ c_i = \\sqrt{\\frac{K_{i}}{\\rho_{i}}},\n",
@@ -215,7 +215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/Advection.ipynb
+++ b/Advection.ipynb
@@ -16,7 +16,7 @@
     "To examine the Python code for this chapter, see:\n",
     "\n",
     " - [exact_solvers/advection.py](exact_solvers/advection.py) ...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/advection.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/advection.py)"
    ]
   },
   {

--- a/Burgers.ipynb
+++ b/Burgers.ipynb
@@ -48,9 +48,9 @@
     "To examine the Python code for this chapter, see:\n",
     "\n",
     " - [exact_solvers/burgers.py](exact_solvers/burgers.py) ...\n",
-    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/burgers.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/burgers.py)\n",
     " - [exact_solvers/burgers_demos.py](exact_solvers/burgers_demos.py)...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/burgers_demos.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/burgers_demos.py)"
    ]
   },
   {

--- a/Burgers_approximate.ipynb
+++ b/Burgers_approximate.ipynb
@@ -83,7 +83,7 @@
     "To examine the Python code for this chapter, see:\n",
     "\n",
     " - [exact_solvers/burgers.py](exact_solvers/burgers.py) ...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/burgers.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/burgers.py)"
    ]
   },
   {

--- a/Euler.ipynb
+++ b/Euler.ipynb
@@ -266,9 +266,9 @@
     "If you wish to examine the Python code for this chapter, see:\n",
     "\n",
     "- [exact_solvers/euler.py](exact_solvers/euler.py) ...\n",
-    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/euler.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/euler.py)\n",
     "- [exact_solvers/euler_demos.py](exact_solvers/euler_demos.py) ...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/euler_demos.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/euler_demos.py)"
    ]
   },
   {

--- a/Euler_approximate.ipynb
+++ b/Euler_approximate.ipynb
@@ -33,7 +33,7 @@
     "To examine the Python code for this chapter, and for the exact Riemann solution, see:\n",
     "\n",
     " - [exact_solvers/euler.py](exact_solvers/euler.py) ...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/euler.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/euler.py)"
    ]
   },
   {
@@ -236,7 +236,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An implementation of this solver for use in Clawpack can be found [here](https://github.com/clawpack/riemann/blob/c0a41c664e9a13d35a113409dea92f3c87648d09/src/rp1_euler_with_efix.f90).  Recall that an exact Riemann solver for the Euler equations appears in [exact_solvers/euler.py](exact_solvers/euler.py)."
+    "An implementation of this solver for use in Clawpack can be found [here](https://github.com/clawpack/riemann/blob/FA16/src/rp1_euler_with_efix.f90).  Recall that an exact Riemann solver for the Euler equations appears in [exact_solvers/euler.py](exact_solvers/euler.py)."
    ]
   },
   {
@@ -616,7 +616,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   },
   "toc": {
    "base_numbering": 1,

--- a/FV_compare.ipynb
+++ b/FV_compare.ipynb
@@ -21,8 +21,8 @@
     "  \n",
     "In this chapter we include extensive sections of code in the notebook.  This is meant to more easily allow the reader to use these as templates for setting up other problems in PyClaw. For the code in this chapter we use approximate Riemann solvers from PyClaw that can be found in these files:\n",
     "\n",
-    "- [euler_1D_py.py,](https://github.com/clawpack/riemann/blob/master/riemann/euler_1D_py.py)\n",
-    "- [shallow_roe_with_efix_1D.](https://github.com/clawpack/riemann/blob/master/riemann/shallow_1D_py.py)"
+    "- [euler_1D_py.py,](https://github.com/clawpack/riemann/blob/FA16/riemann/euler_1D_py.py)\n",
+    "- [shallow_roe_with_efix_1D.](https://github.com/clawpack/riemann/blob/FA16/riemann/shallow_1D_py.py)"
    ]
   },
   {

--- a/Index2.ipynb
+++ b/Index2.ipynb
@@ -38,8 +38,8 @@
     "  2. [Pressureless_flow](Pressureless_flow.ipynb) -- Pressureless gas dynamics\n",
     " \n",
     "## Part VI: Multidimensional systems\n",
-    "  1. [Acoustics](http://nbviewer.jupyter.org/github/maojrs/ipynotebooks/blob/master/acoustics_riemann.ipynb) *[To be improved and incorporated into this project]*\n",
-    "  2. [Elasticity](http://nbviewer.jupyter.org/github/maojrs/ipynotebooks/blob/master/elasticity_riemann.ipynb) *[To be improved and incorporated into this project]*\n",
+    "  1. [Acoustics](http://nbviewer.jupyter.org/github/maojrs/ipynotebooks/blob/FA16/acoustics_riemann.ipynb) *[To be improved and incorporated into this project]*\n",
+    "  2. [Elasticity](http://nbviewer.jupyter.org/github/maojrs/ipynotebooks/blob/FA16/elasticity_riemann.ipynb) *[To be improved and incorporated into this project]*\n",
     "  3. [Kitchen_sink_problem](Kitchen_sink_problem.ipynb) -- The Kitchen Sink: shallow water in cylindrical coordinates"
    ]
   }

--- a/Introduction.ipynb
+++ b/Introduction.ipynb
@@ -24,7 +24,7 @@
     "The plots shown in this chapter are created using a function that is defined in the Python module \n",
     "\n",
     " - [exact_solvers/shallow_water.py](exact_solvers/shallow_water.py) ...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_water.py)\n",
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/shallow_water.py)\n",
     "\n",
     "In all of the notebooks, much of the Python code that is used behind the scenes is imported from modules in the `exact_solvers` subdirectory, including the grungy details to make nice plots.  Much of the code for actually solving the Riemann problems is also in these modules, so if you want to dive into the implementations, you will need to examine that code.  Near the top of each notebook there is a link to the relevant modules for that chapter.  The versions on Github may be nicer to read since the syntax is automatically highlighted.\n",
     "\n",

--- a/Nonconvex_scalar.ipynb
+++ b/Nonconvex_scalar.ipynb
@@ -75,9 +75,9 @@
     "If you wish to examine the Python code for this chapter, please see:\n",
     "\n",
     " - [exact_solvers/nonconvex.py](exact_solvers/nonconvex.py) ...\n",
-    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/nonconvex.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/nonconvex.py)\n",
     " - [exact_solvers/nonconvex_demos.py](exact_solvers/nonconvex_demos.py) ...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/nonconvex_demos.py)\n"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/nonconvex_demos.py)\n"
    ]
   },
   {

--- a/Preface.ipynb
+++ b/Preface.ipynb
@@ -61,7 +61,7 @@
     "In order to run the code in the Jupyter notebook version of the book, you will need to have certain tools and libraries installed on a computer, either locally or in the cloud.  There are multiple convenient ways to do this.\n",
     "\n",
     "  - On your own computer: follow the [installation instructions](https://github.com/clawpack/riemann_book#installation)\n",
-    "  - With Docker: follow [these instructions](https://github.com/clawpack/riemann_book/blob/master/Docker.md) to use the `Dockerfile` that is included in the Github repository.\n",
+    "  - With Docker: follow [these instructions](https://github.com/clawpack/riemann_book/blob/FA16/Docker.md) to use the `Dockerfile` that is included in the Github repository.\n",
     "  - With Binder: The cloud service [binder](https://mybinder.org/) allows you to start up a notebook server running notebooks from any Git repository (assuming it specifies the dependencies properly).  You can try it out for these notebooks at [this link](https://mybinder.org/v2/gh/clawpack/riemann_book/master).\n",
     "    This should start up a notebook server on a [Jupyterhub](https://jupyterhub.readthedocs.io/en/latest/) that lets you execute all the notebooks in your browser with no local installation of the notebooks or dependencies required."
    ]

--- a/Shallow_tracer.ipynb
+++ b/Shallow_tracer.ipynb
@@ -74,9 +74,9 @@
     "If you wish to examine the Python code for this chapter, see\n",
     "\n",
     " - [exact_solvers/shallow_water.py](exact_solvers/shallow_water.py) ...\n",
-    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_water.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/shallow_water.py)\n",
     " - [exact_solvers/shallow_demos.py](exact_solvers/shallow_demos.py) ...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_demos.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/shallow_demos.py)"
    ]
   },
   {

--- a/Shallow_water.ipynb
+++ b/Shallow_water.ipynb
@@ -89,9 +89,9 @@
     "If you wish to examine the Python code for this chapter, see\n",
     "\n",
     " - [exact_solvers/shallow_water.py](exact_solvers/shallow_water.py) ...\n",
-    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_water.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/shallow_water.py)\n",
     " - [exact_solvers/shallow_demos.py](exact_solvers/shallow_demos.py) ...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_demos.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/shallow_demos.py)"
    ]
   },
   {

--- a/Shallow_water_approximate.ipynb
+++ b/Shallow_water_approximate.ipynb
@@ -25,7 +25,7 @@
     "To examine the Python code for this chapter, and for the exact Riemann solution, see:\n",
     "\n",
     " - [exact_solvers/shallow_water.py](exact_solvers/shallow_water.py) ...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/shallow_water.py)"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/shallow_water.py)"
    ]
   },
   {
@@ -457,7 +457,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An implementation of this solver for use in Clawpack can be found [here](https://github.com/clawpack/riemann/blob/c0a41c664e9a13d35a113409dea92f3c87648d09/src/rp1_shallow_roe_with_efix.f90)."
+    "An implementation of this solver for use in Clawpack can be found [here](https://github.com/clawpack/riemann/blob/FA16/src/rp1_shallow_roe_with_efix.f90)."
    ]
   },
   {
@@ -713,7 +713,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An implementation of this solver for use in Clawpack can be found [here](https://github.com/clawpack/riemann/blob/c0a41c664e9a13d35a113409dea92f3c87648d09/src/rp1_shallow_hlle.f90)."
+    "An implementation of this solver for use in Clawpack can be found [here](https://github.com/clawpack/riemann/blob/FA16/src/rp1_shallow_hlle.f90)."
    ]
   },
   {

--- a/Traffic_flow.ipynb
+++ b/Traffic_flow.ipynb
@@ -23,9 +23,9 @@
     "If you wish to examine the Python code for this chapter, please see:\n",
     "\n",
     " - [exact_solvers/traffic_LWR.py](exact_solvers/traffic_LWR.py) ...\n",
-    "   [on github,](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/traffic_LWR.py)\n",
+    "   [on github,](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/traffic_LWR.py)\n",
     " - [exact_solvers/traffic_demos.py](exact_solvers/traffic_demos.py) ...\n",
-    "   [on github.](https://github.com/clawpack/riemann_book/blob/master/exact_solvers/traffic_demos.py)\n"
+    "   [on github.](https://github.com/clawpack/riemann_book/blob/FA16/exact_solvers/traffic_demos.py)\n"
    ]
   },
   {


### PR DESCRIPTION
To agree with changes in the SIAM book version. We will maintain branch FA16 in this repository and also in clawpack/riemann pointing to versions that agree with what was used in producing the book.