### PR TITLE
Force `nsteps` to be `int` in call to `linspace`

### DIFF
--- a/utils/riemann_tools.py
+++ b/utils/riemann_tools.py
@@ -565,7 +565,7 @@ def compute_riemann_trajectories(states, s, riemann_eval, wave_types=None,
 
     nsteps = 200.
     dt = 1./nsteps
-    t_traj = np.linspace(0,1,nsteps+1)
+    t_traj = np.linspace(0,1,int(nsteps+1))
     q_old = riemann_eval(xx/1e-15)
     for n in range(1,len(t_traj)):
         q_new = riemann_eval(xx/t_traj[n])


### PR DESCRIPTION
I just tried to run the book and ran into NumPy complaining about `nsteps` not being an `int` in a call to `linspace`.  This fixes it although I am not entirely sure why `nsteps` has become a `float`.