### PR TITLE
Binder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install ipywidgets
 RUN pip install --user -e jupyter_contrib_nbextensions
 
 ENV PATH ${PATH}:/home/jovyan/.local/bin
-RUN pip install "traitlets>=5.0" "nbformat>=5.0" "jupyter-client>=6.1.5"
+RUN pip install "traitlets>=5.0" "nbformat>=5.0" "jupyter-core>=4.6.0" "jupyter-client>=6.1.5"
 RUN jupyter contrib nbextension install --user
 RUN jupyter nbextension enable widgetsnbextension --py
 RUN jupyter nbextension enable equation-numbering/main


### PR DESCRIPTION
The cloud-version of the FA16-branch and the master-branch doesn't work for me.
Here's the log for the FA16-branch:
```
[...]
Step 9/13 : RUN jupyter contrib nbextension install --user
 ---> Running in f6a10854d5c2
Traceback (most recent call last):
  File "/home/jovyan/.local/bin/jupyter-contrib", line 10, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.7/site-packages/jupyter_core/application.py", line 266, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/traitlets/config/application.py", line 656, in launch_instance
    app = cls.instance(**kwargs)
  File "/opt/conda/lib/python3.7/site-packages/traitlets/config/configurable.py", line 412, in instance
    inst = cls(*args, **kwargs)
  File "/home/jovyan/.local/lib/python3.7/site-packages/jupyter_contrib_core/application.py", line 27, in __init__
    self._refresh_subcommands()
  File "/home/jovyan/.local/lib/python3.7/site-packages/jupyter_contrib_core/application.py", line 43, in _refresh_subcommands
    get_subcommands_dict = entrypoint.load()
  File "/opt/conda/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2433, in load
    self.require(*args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2456, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/opt/conda/lib/python3.7/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (traitlets 4.3.2 (/opt/conda/lib/python3.7/site-packages), Requirement.parse('traitlets>=5.0'), {'nbconvert'})
Removing intermediate container f6a10854d5c2
[...]
```
The PR contains some changes to get the repo working.