### PR TITLE
Use == for comparison with string literals.

### DIFF
--- a/exact_solvers/euler_tammann.py
+++ b/exact_solvers/euler_tammann.py
@@ -216,11 +216,11 @@ def exact_riemann_solution(ql, qr, auxl, auxr, varin = 'primitive', varout = 'pr
     #speeds = [(ws[0],ws[1]),ws[2],(ws[3],ws[4])]
     speeds = [[], ws[2], []]
     wave_types = [wave1, 'contact', wave3]
-    if wave_types[0] is 'shock':
+    if wave_types[0] == 'shock':
         speeds[0] = ws[0]
     else:
         speeds[0] = (ws[0],ws[1])
-    if wave_types[2] is 'shock':
+    if wave_types[2] == 'shock':
         speeds[2] = ws[3]
     else:
         speeds[2] = (ws[3],ws[4])

--- a/exact_solvers/nonlinear_elasticity.py
+++ b/exact_solvers/nonlinear_elasticity.py
@@ -139,11 +139,11 @@ def exact_riemann_solution(q_l,q_r,aux_l,aux_r,phase_plane_curves=False):
 
     states = np.column_stack([q_l, q_star_l, q_star_r, q_r])
     speeds = [[], ws[2], []]
-    if wave_types[0] is 'shock':
+    if wave_types[0] == 'shock':
         speeds[0] = ws[0]
     else:
         speeds[0] = (ws[0],ws[1])
-    if wave_types[2] is 'shock':
+    if wave_types[2] == 'shock':
         speeds[2] = ws[3]
     else:
         speeds[2] = (ws[3],ws[4])

--- a/exact_solvers/shallow_water.py
+++ b/exact_solvers/shallow_water.py
@@ -175,11 +175,11 @@ def exact_riemann_solution(q_l, q_r, grav=1., force_waves=None,
 
     states = np.column_stack([q_l,q_m,q_r])
     speeds = [[], []]
-    if wave_types[0] is 'shock':
+    if wave_types[0] == 'shock':
         speeds[0] = ws[0]
     else:
         speeds[0] = (ws[0],ws[1])
-    if wave_types[1] is 'shock':
+    if wave_types[1] == 'shock':
         speeds[1] = ws[2]
     else:
         speeds[1] = (ws[2],ws[3])

--- a/exact_solvers/traffic_ramps.py
+++ b/exact_solvers/traffic_ramps.py
@@ -145,7 +145,7 @@ def phase_plane_plot(q_l, q_r, D, states=None, speeds=None,
     fluxes = [f(state) for state in states]
 
     for i, w in enumerate(wave_types):
-        if w is 'raref':
+        if w == 'raref':
             q = np.linspace(states[i],states[i+1],500)
             ff = f(q)
             axes.plot(q,ff,color=colors['raref'],lw=3)


### PR DESCRIPTION
In recent versions of Python, using "is" to compare
with a string literal generates a warning.  This patch
avoids those warnings but does not change the behavior
of the code.