### PR TITLE
Avoid plotting too-short arrows

### DIFF
--- a/exact_solvers/burgers_demos.py
+++ b/exact_solvers/burgers_demos.py
@@ -29,7 +29,8 @@ def multivalued_solution(t,fig=0):
         numarrows = 7
         arrowIndexList = np.linspace(len(x)/3,2*len(x)/3,numarrows, dtype = int)
         for i in arrowIndexList:
-            plt.arrow(x[i], y[i], np.abs(t*y[i]-0.4), 0, head_width=0.02, head_length=0.4, fc='k', ec='k')
+            if t*y[i]-0.4 >0.1:
+                plt.arrow(x[i], y[i], np.abs(t*y[i]-0.4), 0, head_width=0.02, head_length=0.4, fc='k', ec='k')
     if fig==0: plt.show()
 
 def shock():


### PR DESCRIPTION
This removes a visual bug, shown in the attachment.  In this visualization, short arrows go past where they should end.  And one arrow is plotted with length zero, which seems to result in a vertical line.  This PR just avoids plotting any arrows until there is enough space for them in the plot (second screenshot).

<img width="645" alt="Screen Shot 2023-01-22 at 8 52 36 AM" src="https://user-images.githubusercontent.com/697763/213902696-8f0db98c-e5f1-44f8-9ce6-450732300499.png">
<img width="625" alt="Screen Shot 2023-01-22 at 8 56 16 AM" src="https://user-images.githubusercontent.com/697763/213902746-6cc6fcc2-0325-4b2a-8a9b-f49bad536a4c.png">
